### PR TITLE
Run a watcher test

### DIFF
--- a/typescript/optics-deploy/config/testnets/fuji.ts
+++ b/typescript/optics-deploy/config/testnets/fuji.ts
@@ -24,7 +24,10 @@ export const chain = toChain(chainJson);
 export const devConfig: CoreConfig = {
   environment: 'dev',
   updater: '0x91631845fab02614e53e5F5A68dFBB0E2f1a9B6d',
-  watchers: ['0x3019Bf39Df97942F2C53EFc6e831b82D158593CF'],
+  watchers: [
+    '0x3019Bf39Df97942F2C53EFc6e831b82D158593CF',
+    '0x8358cc8d0105aD63cF0914481bEa9c4b786c3016',
+  ],
   recoveryManager: '0x4FbBB2b0820CF0cF027BbB58DC7F7f760BC0c57e',
   optimisticSeconds: 10,
   recoveryTimelock: 180,

--- a/typescript/optics-deploy/scripts/dev/create-improper-update.ts
+++ b/typescript/optics-deploy/scripts/dev/create-improper-update.ts
@@ -57,15 +57,13 @@ async function main() {
     new ethers.Wallet(process.env.ALFAJORES_DEPLOYER_KEY!),
   );
 
-  const fujiDeploy = deploys.find((_) => _.chain.name === 'fuji')!;
   const kovanDeploy = deploys.find((_) => _.chain.name === 'kovan')!;
 
-  const kovanHome = kovanDeploy.contracts.home!;
-  const kovanReplica =
-    fujiDeploy.contracts.replicas[kovanDeploy?.chain.domain!]!;
+  const kovanHome = devCommunity.mustGetCore('kovan').home;
+  const kovanReplica = devCommunity.mustGetReplicaFor('kovan', 'fuji');
 
-  const homeRoot = await kovanHome.proxy.committedRoot();
-  const replicaRoot = await kovanReplica.proxy.committedRoot();
+  const homeRoot = await kovanHome.committedRoot();
+  const replicaRoot = await kovanReplica.committedRoot();
 
   console.log(`homeRoot: ${homeRoot}, replicaRoot: ${replicaRoot}`);
 
@@ -81,12 +79,12 @@ async function main() {
   const improperUpdate = await updater.signUpdate(homeRoot, fakeRoot);
 
   console.log(improperUpdate);
-  const gas = await kovanReplica.proxy.estimateGas.update(
+  const gas = await kovanReplica.estimateGas.update(
     homeRoot,
     fakeRoot,
     improperUpdate.signature,
   );
-  const ret = await kovanReplica.proxy.callStatic.update(
+  const ret = await kovanReplica.callStatic.update(
     homeRoot,
     fakeRoot,
     improperUpdate.signature,

--- a/typescript/optics-deploy/scripts/dev/create-improper-update.ts
+++ b/typescript/optics-deploy/scripts/dev/create-improper-update.ts
@@ -1,0 +1,97 @@
+import { devCommunity } from 'optics-multi-provider-community';
+import { ethers } from 'ethers';
+import { configPath, networks } from './agentConfig';
+import { makeCoreDeploys } from '../../src/core/CoreDeploy';
+const deploys = makeCoreDeploys(
+  configPath,
+  networks,
+  (_) => _.chain,
+  (_) => _.devConfig,
+);
+
+function domainHash(domain: Number): string {
+  return ethers.utils.solidityKeccak256(
+    ['uint32', 'string'],
+    [domain, 'OPTICS'],
+  );
+}
+
+class Updater {
+  localDomain: number;
+  signer: ethers.Signer;
+  address: string;
+  constructor(signer: ethers.Signer, address: string, localDomain: number) {
+    this.localDomain = localDomain ? localDomain : 0;
+    this.signer = signer;
+    this.address = address;
+  }
+
+  domainHash() {
+    return domainHash(this.localDomain);
+  }
+
+  message(oldRoot: string, newRoot: string) {
+    return ethers.utils.concat([this.domainHash(), oldRoot, newRoot]);
+  }
+  async signUpdate(oldRoot: string, newRoot: string) {
+    let message = this.message(oldRoot, newRoot);
+    let msgHash = ethers.utils.arrayify(ethers.utils.keccak256(message));
+    let signature = await this.signer.signMessage(msgHash);
+    return {
+      origin: this.localDomain,
+      oldRoot,
+      newRoot,
+      signature,
+    };
+  }
+}
+
+async function main() {
+  devCommunity.registerRpcProvider('alfajores', process.env.ALFAJORES_RPC!);
+  devCommunity.registerRpcProvider('gorli', process.env.GORLI_RPC!);
+  devCommunity.registerRpcProvider('kovan', process.env.KOVAN_RPC!);
+  devCommunity.registerRpcProvider('mumbai', process.env.MUMBAI_RPC!);
+  devCommunity.registerRpcProvider('fuji', process.env.FUJI_RPC!);
+  devCommunity.registerSigner(
+    'alfajores',
+    new ethers.Wallet(process.env.ALFAJORES_DEPLOYER_KEY!),
+  );
+
+  const fujiDeploy = deploys.find((_) => _.chain.name === 'fuji')!;
+  const kovanDeploy = deploys.find((_) => _.chain.name === 'kovan')!;
+
+  const kovanHome = kovanDeploy.contracts.home!;
+  const kovanReplica =
+    fujiDeploy.contracts.replicas[kovanDeploy?.chain.domain!]!;
+
+  const homeRoot = await kovanHome.proxy.committedRoot();
+  const replicaRoot = await kovanReplica.proxy.committedRoot();
+
+  console.log(`homeRoot: ${homeRoot}, replicaRoot: ${replicaRoot}`);
+
+  const updaterSigner = new ethers.Wallet('0x0');
+  const updater = new Updater(
+    // @ts-ignore
+    updaterSigner,
+    updaterSigner.address,
+    kovanDeploy.chain.domain,
+  );
+
+  const fakeRoot = ethers.utils.formatBytes32String('fake root');
+  const improperUpdate = await updater.signUpdate(homeRoot, fakeRoot);
+
+  console.log(improperUpdate);
+  const gas = await kovanReplica.proxy.estimateGas.update(
+    homeRoot,
+    fakeRoot,
+    improperUpdate.signature,
+  );
+  const ret = await kovanReplica.proxy.callStatic.update(
+    homeRoot,
+    fakeRoot,
+    improperUpdate.signature,
+  );
+
+  console.log(gas, ret);
+}
+main().then(console.log).catch(console.error);

--- a/typescript/optics-deploy/scripts/dev/enroll-watchers.ts
+++ b/typescript/optics-deploy/scripts/dev/enroll-watchers.ts
@@ -1,0 +1,50 @@
+import { devCommunity } from 'optics-multi-provider-community';
+import { ethers } from 'ethers';
+import { configPath, networks } from './agentConfig';
+import { ViolationType } from '../../src/checks';
+import { CoreInvariantChecker } from '../../src/core/checks';
+import { makeCoreDeploys, CoreDeploy } from '../../src/core/CoreDeploy';
+import { expectCalls, GovernanceCallBatchBuilder } from '../../src/core/govern';
+
+const deploys = makeCoreDeploys(
+  configPath,
+  networks,
+  (_) => _.chain,
+  (_) => _.devConfig,
+);
+
+async function main() {
+  devCommunity.registerRpcProvider('alfajores', process.env.ALFAJORES_RPC!);
+  devCommunity.registerRpcProvider('gorli', process.env.GORLI_RPC!);
+  devCommunity.registerRpcProvider('kovan', process.env.KOVAN_RPC!);
+  devCommunity.registerRpcProvider('mumbai', process.env.MUMBAI_RPC!);
+  devCommunity.registerRpcProvider('fuji', process.env.FUJI_RPC!);
+  devCommunity.registerSigner(
+    'alfajores',
+    new ethers.Wallet(process.env.ALFAJORES_DEPLOYER_KEY!),
+  );
+
+  const checker = new CoreInvariantChecker(deploys);
+  await checker.checkDeploys();
+  checker.expectViolations([ViolationType.Watcher], [4]);
+  const builder = new GovernanceCallBatchBuilder(
+    deploys,
+    devCommunity,
+    checker.violations,
+  );
+  const batch = await builder.build();
+  const domains = deploys.map((d: CoreDeploy) => d.chain.domain);
+
+  await batch.build();
+  console.log(batch);
+  // only expect 4 calls for fuji
+  expectCalls(
+    batch,
+    domains,
+    deploys.map((d) => (d.chain.name === 'fuji' ? 4 : 0)),
+  );
+  // Change to `batch.execute` in order to run.
+  const receipts = await batch.estimateGas();
+  console.log(receipts);
+}
+main().then(console.log).catch(console.error);

--- a/typescript/optics-deploy/src/core/govern.ts
+++ b/typescript/optics-deploy/src/core/govern.ts
@@ -134,6 +134,11 @@ export function expectCalls(
 ) {
   expect(domains).to.have.lengthOf(count.length);
   domains.forEach((domain: number, i: number) => {
-    expect(batch.calls.get(domain)).to.have.lengthOf(count[i]);
+    const calls = batch.calls.get(domain);
+    if (count[i] === 0) {
+      expect(calls).to.be.undefined;
+    } else {
+      expect(calls).to.have.lengthOf(count[i]);
+    }
   });
 }


### PR DESCRIPTION
The test works as following:
1. Enroll a new watcher on fuji
2. Create an improper update on the Kovan replica on Fuji
3. Enqueue a message on Kovan home, causing a double update
4. Observe the unenrollment of the replica