### PR TITLE
Multisig validator rust agents

### DIFF
--- a/rust/abacus-base/src/agent.rs
+++ b/rust/abacus-base/src/agent.rs
@@ -2,7 +2,7 @@ use crate::{
     cancel_task,
     metrics::CoreMetrics,
     settings::{IndexSettings, Settings},
-    CachingInbox, CachingOutbox,
+    CachingInbox, CachingOutbox, InboxValidatorManagers,
 };
 use abacus_core::db::DB;
 use async_trait::async_trait;
@@ -21,6 +21,8 @@ pub struct AbacusAgentCore {
     pub outbox: Arc<CachingOutbox>,
     /// A map of boxed Inboxes
     pub inboxes: HashMap<String, Arc<CachingInbox>>,
+    /// A map of boxed InboxValidatorManagers
+    pub inbox_validator_managers: HashMap<String, Arc<InboxValidatorManagers>>,
     /// A persistent KV Store (currently implemented as rocksdb)
     pub db: DB,
     /// Prometheus metrics
@@ -65,9 +67,19 @@ pub trait Agent: Send + Sync + std::fmt::Debug + AsRef<AbacusAgentCore> {
         &self.as_ref().inboxes
     }
 
-    /// Get a reference to a inbox by its name
+    /// Get a reference to an inbox by its name
     fn inbox_by_name(&self, name: &str) -> Option<Arc<CachingInbox>> {
         self.inboxes().get(name).map(Clone::clone)
+    }
+
+    /// Get a reference to the inbox_validator_managers map
+    fn inbox_validator_managers(&self) -> &HashMap<String, Arc<InboxValidatorManagers>> {
+        &self.as_ref().inbox_validator_managers
+    }
+
+    /// Get a reference to an InboxValidatorManager in by its name
+    fn inbox_validator_manager_by_name(&self, name: &str) -> Option<Arc<InboxValidatorManagers>> {
+        self.inbox_validator_managers().get(name).map(Clone::clone)
     }
 
     /// Run tasks

--- a/rust/abacus-base/src/agent.rs
+++ b/rust/abacus-base/src/agent.rs
@@ -40,27 +40,6 @@ pub struct AbacusAgentCore {
     pub settings: crate::settings::Settings,
 }
 
-impl AbacusAgentCore {
-    /// Constructor
-    pub fn new(
-        outbox: Arc<CachingOutbox>,
-        inboxes: HashMap<String, InboxContracts>,
-        db: DB,
-        metrics: Arc<CoreMetrics>,
-        indexer: IndexSettings,
-        settings: crate::settings::Settings,
-    ) -> Result<AbacusAgentCore> {
-        Ok(AbacusAgentCore {
-            outbox,
-            inboxes,
-            db,
-            metrics,
-            indexer,
-            settings,
-        })
-    }
-}
-
 /// A trait for an abacus agent
 #[async_trait]
 pub trait Agent: Send + Sync + std::fmt::Debug + AsRef<AbacusAgentCore> {
@@ -97,9 +76,7 @@ pub trait Agent: Send + Sync + std::fmt::Debug + AsRef<AbacusAgentCore> {
 
     /// Get a reference to an inbox by its name
     fn inbox_by_name(&self, name: &str) -> Option<InboxContracts> {
-        self.inboxes()
-            .get(name)
-            .map(Clone::clone)
+        self.inboxes().get(name).map(Clone::clone)
     }
 
     /// Run tasks

--- a/rust/abacus-base/src/agent.rs
+++ b/rust/abacus-base/src/agent.rs
@@ -74,7 +74,7 @@ pub trait Agent: Send + Sync + std::fmt::Debug + AsRef<AbacusAgentCore> {
         &self.as_ref().inboxes
     }
 
-    /// Get a reference to an inbox by its name
+    /// Get a reference to an inbox's contracts by its name
     fn inbox_by_name(&self, name: &str) -> Option<InboxContracts> {
         self.inboxes().get(name).map(Clone::clone)
     }

--- a/rust/abacus-base/src/inbox.rs
+++ b/rust/abacus-base/src/inbox.rs
@@ -1,6 +1,6 @@
 use abacus_core::{
     accumulator::merkle::Proof, db::AbacusDB, AbacusCommon, AbacusMessage, ChainCommunicationError,
-    Checkpoint, Inbox, MessageStatus, SignedCheckpoint, TxOutcome,
+    Checkpoint, Inbox, MessageStatus, TxOutcome,
 };
 use abacus_test::mocks::inbox::MockInboxContract;
 use async_trait::async_trait;
@@ -98,13 +98,6 @@ impl Inbox for CachingInbox {
 
     async fn message_status(&self, leaf: H256) -> Result<MessageStatus, ChainCommunicationError> {
         self.inbox.message_status(leaf).await
-    }
-
-    async fn submit_checkpoint(
-        &self,
-        signed_checkpoint: &SignedCheckpoint,
-    ) -> Result<TxOutcome, ChainCommunicationError> {
-        self.inbox.submit_checkpoint(signed_checkpoint).await
     }
 }
 
@@ -250,19 +243,6 @@ impl Inbox for InboxVariants {
             InboxVariants::Ethereum(inbox) => inbox.prove_and_process(message, proof).await,
             InboxVariants::Mock(mock_inbox) => mock_inbox.prove_and_process(message, proof).await,
             InboxVariants::Other(inbox) => inbox.prove_and_process(message, proof).await,
-        }
-    }
-
-    async fn submit_checkpoint(
-        &self,
-        signed_checkpoint: &SignedCheckpoint,
-    ) -> Result<TxOutcome, ChainCommunicationError> {
-        match self {
-            InboxVariants::Ethereum(inbox) => inbox.submit_checkpoint(signed_checkpoint).await,
-            InboxVariants::Mock(mock_inbox) => {
-                mock_inbox.submit_checkpoint(signed_checkpoint).await
-            }
-            InboxVariants::Other(inbox) => inbox.submit_checkpoint(signed_checkpoint).await,
         }
     }
 }

--- a/rust/abacus-base/src/lib.rs
+++ b/rust/abacus-base/src/lib.rs
@@ -44,3 +44,6 @@ pub use traits::*;
 
 mod types;
 pub use types::*;
+
+mod validator_manager;
+pub use validator_manager::*;

--- a/rust/abacus-base/src/settings/chains.rs
+++ b/rust/abacus-base/src/settings/chains.rs
@@ -116,11 +116,7 @@ impl ChainSetup<InboxAddresses> {
         signer: Option<Signers>,
         // inbox_address: Address,
     ) -> Result<InboxValidatorManagers, Report> {
-        let inbox_address = self
-            .addresses
-            .inbox
-            .parse::<ethers::types::Address>()?
-            .into();
+        let inbox_address = self.addresses.inbox.parse::<ethers::types::Address>()?;
         match &self.chain {
             ChainConf::Ethereum(conf) => Ok(InboxValidatorManagerVariants::Ethereum(
                 make_inbox_validator_manager(

--- a/rust/abacus-base/src/settings/chains.rs
+++ b/rust/abacus-base/src/settings/chains.rs
@@ -1,4 +1,5 @@
 use color_eyre::Report;
+use ethers::types::Address;
 use serde::Deserialize;
 
 use abacus_core::{ContractLocator, Signers};
@@ -87,6 +88,7 @@ impl ChainSetup {
     pub async fn try_into_inbox_validator_manager(
         &self,
         signer: Option<Signers>,
+        inbox_address: Address,
     ) -> Result<InboxValidatorManagers, Report> {
         match &self.chain {
             ChainConf::Ethereum(conf) => Ok(InboxValidatorManagerVariants::Ethereum(
@@ -98,6 +100,7 @@ impl ChainSetup {
                         address: self.address.parse::<ethers::types::Address>()?.into(),
                     },
                     signer,
+                    inbox_address,
                 )
                 .await?,
             )

--- a/rust/abacus-base/src/settings/chains.rs
+++ b/rust/abacus-base/src/settings/chains.rs
@@ -35,11 +35,12 @@ pub struct OutboxAddresses {
 
 /// Contracts for an inbox
 #[derive(Clone, Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
 pub struct InboxAddresses {
     /// Address of the Inbox contract
     pub inbox: String,
     /// Address of the InboxValidatorManager contract
-    pub validatormanager: String,
+    pub validator_manager: String,
 }
 
 /// A chain setup is a domain ID, an address on that chain (where the outbox or
@@ -129,7 +130,7 @@ impl ChainSetup<InboxAddresses> {
                         domain: self.domain.parse().expect("invalid uint"),
                         address: self
                             .addresses
-                            .validatormanager
+                            .validator_manager
                             .parse::<ethers::types::Address>()?
                             .into(),
                     },

--- a/rust/abacus-base/src/settings/chains.rs
+++ b/rust/abacus-base/src/settings/chains.rs
@@ -26,14 +26,14 @@ impl Default for ChainConf {
     }
 }
 
-/// Contracts for an outbox
+/// Addresses for outbox chain contracts
 #[derive(Clone, Debug, Deserialize, Default)]
 pub struct OutboxAddresses {
     /// Address of the Outbox contract
     pub outbox: String,
 }
 
-/// Contracts for an inbox
+/// Addresses for inbox chain contracts
 #[derive(Clone, Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct InboxAddresses {
@@ -51,7 +51,7 @@ pub struct ChainSetup<T> {
     pub name: String,
     /// Chain domain identifier
     pub domain: String,
-    /// Address of contract on the chain
+    /// Addresses of contracts on the chain
     pub addresses: T,
     /// The chain connection details
     #[serde(flatten)]

--- a/rust/abacus-base/src/settings/mod.rs
+++ b/rust/abacus-base/src/settings/mod.rs
@@ -220,7 +220,7 @@ impl Settings {
         &self,
         db: DB,
     ) -> Result<HashMap<String, InboxContracts>, Report> {
-        let mut result = HashMap::default();
+        let mut result = HashMap::new();
         for (k, v) in self.inboxes.iter().filter(|(_, v)| v.disabled.is_none()) {
             if k != &v.name {
                 bail!(

--- a/rust/abacus-base/src/settings/mod.rs
+++ b/rust/abacus-base/src/settings/mod.rs
@@ -187,7 +187,7 @@ pub struct Settings {
     /// The outbox configuration
     pub outbox: ChainSetup<OutboxAddresses>,
     /// Configurations for contracts on inbox chains
-    pub inbox_contracts: HashMap<String, ChainSetup<InboxAddresses>>,
+    pub inboxes: HashMap<String, ChainSetup<InboxAddresses>>,
     /// The tracing configuration
     pub tracing: TracingConfig,
     /// Transaction signers
@@ -202,7 +202,7 @@ impl Settings {
             metrics: self.metrics.clone(),
             index: self.index.clone(),
             outbox: self.outbox.clone(),
-            inbox_contracts: self.inbox_contracts.clone(),
+            inboxes: self.inboxes.clone(),
             tracing: self.tracing.clone(),
             signers: self.signers.clone(),
         }
@@ -222,7 +222,7 @@ impl Settings {
     ) -> Result<HashMap<String, InboxContracts>, Report> {
         let mut result = HashMap::default();
         for (k, v) in self
-            .inbox_contracts
+            .inboxes
             .iter()
             .filter(|(_, v)| v.disabled.is_none())
         {

--- a/rust/abacus-base/src/settings/mod.rs
+++ b/rust/abacus-base/src/settings/mod.rs
@@ -189,7 +189,7 @@ pub struct Settings {
     /// The inbox configurations
     pub inboxes: HashMap<String, ChainSetup>,
     /// The InboxValidatorManager configurations
-    pub inbox_validator_managers: HashMap<String, ChainSetup>,
+    pub inboxvalidatormanagers: HashMap<String, ChainSetup>,
     /// The tracing configuration
     pub tracing: TracingConfig,
     /// Transaction signers
@@ -205,7 +205,7 @@ impl Settings {
             index: self.index.clone(),
             outbox: self.outbox.clone(),
             inboxes: self.inboxes.clone(),
-            inbox_validator_managers: self.inbox_validator_managers.clone(),
+            inboxvalidatormanagers: self.inboxvalidatormanagers.clone(),
             tracing: self.tracing.clone(),
             signers: self.signers.clone(),
         }
@@ -250,7 +250,7 @@ impl Settings {
     ) -> Result<HashMap<String, Arc<InboxValidatorManagers>>, Report> {
         let mut result = HashMap::default();
         for (k, v) in self
-            .inbox_validator_managers
+            .inboxvalidatormanagers
             .iter()
             .filter(|(_, v)| v.disabled.is_none())
         {

--- a/rust/abacus-base/src/types/checkpoint_syncer.rs
+++ b/rust/abacus-base/src/types/checkpoint_syncer.rs
@@ -57,10 +57,7 @@ impl MultisigCheckpointSyncerConf {
     pub fn try_into_multisig_checkpoint_syncer(&self) -> Result<MultisigCheckpointSyncer, Report> {
         let mut checkpoint_syncers = HashMap::new();
         for (key, value) in self.checkpointsyncers.iter() {
-            checkpoint_syncers.insert(
-                Address::from_str(&key)?,
-                value.try_into_checkpoint_syncer()?,
-            );
+            checkpoint_syncers.insert(Address::from_str(key)?, value.try_into_checkpoint_syncer()?);
         }
         Ok(MultisigCheckpointSyncer::new(
             self.threshold,

--- a/rust/abacus-base/src/types/checkpoint_syncer.rs
+++ b/rust/abacus-base/src/types/checkpoint_syncer.rs
@@ -49,14 +49,14 @@ pub struct MultisigCheckpointSyncerConf {
     /// The quorum threshold
     threshold: usize,
     /// The checkpoint syncer for each valid validator signer address
-    checkpoint_syncers: HashMap<String, CheckpointSyncerConf>,
+    checkpointsyncers: HashMap<String, CheckpointSyncerConf>,
 }
 
 impl MultisigCheckpointSyncerConf {
     /// Get a MultisigCheckpointSyncer from the config
     pub fn try_into_multisig_checkpoint_syncer(&self) -> Result<MultisigCheckpointSyncer, Report> {
         let mut checkpoint_syncers = HashMap::new();
-        for (key, value) in self.checkpoint_syncers.iter() {
+        for (key, value) in self.checkpointsyncers.iter() {
             checkpoint_syncers.insert(
                 Address::from_str(&key)?,
                 value.try_into_checkpoint_syncer()?,

--- a/rust/abacus-base/src/types/mod.rs
+++ b/rust/abacus-base/src/types/mod.rs
@@ -1,7 +1,9 @@
 mod checkpoint_syncer;
 mod local_storage;
 mod s3_storage;
+mod multisig;
 
 pub use checkpoint_syncer::*;
 pub use local_storage::*;
 pub use s3_storage::*;
+pub use multisig::*;

--- a/rust/abacus-base/src/types/mod.rs
+++ b/rust/abacus-base/src/types/mod.rs
@@ -1,9 +1,9 @@
 mod checkpoint_syncer;
 mod local_storage;
-mod s3_storage;
 mod multisig;
+mod s3_storage;
 
 pub use checkpoint_syncer::*;
 pub use local_storage::*;
-pub use s3_storage::*;
 pub use multisig::*;
+pub use s3_storage::*;

--- a/rust/abacus-base/src/types/multisig.rs
+++ b/rust/abacus-base/src/types/multisig.rs
@@ -1,0 +1,185 @@
+use std::collections::{HashMap, hash_map::Entry};
+
+use abacus_core::{Checkpoint, SignedCheckpoint};
+use ethers::prelude::{Address, Signature};
+use ethers::types::H256;
+
+use color_eyre::Result;
+
+use crate::{CheckpointSyncer, CheckpointSyncers};
+
+/// Fetches signed checkpoints from multiple validators to provide to multisig validator managers
+pub struct MultisigCheckpointSyncer {
+    /// The quorum threshold
+    threshold: usize,
+    /// The checkpoint syncer for each valid validator signer address
+    checkpoint_syncers: HashMap<Address, CheckpointSyncers>,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum MultisigSignedCheckpointError {
+    /// The signed checkpoint has no signatures
+    #[error("Multisig signed checkpoint has no signatures")]
+    EmptySignatures()
+}
+
+struct SignedCheckpointWithSigner {
+    signer: Address,
+    signed_checkpoint: SignedCheckpoint,
+}
+
+pub struct MultisigSignedCheckpoint {
+    checkpoint: Checkpoint,
+    signatures: Vec<Signature>
+}
+
+impl TryFrom<&mut Vec<SignedCheckpointWithSigner>> for MultisigSignedCheckpoint {
+    type Error = MultisigSignedCheckpointError;
+
+    /// Given multiple signed checkpoints with their signer, creates a MultisigSignedCheckpoint
+    fn try_from(signed_checkpoints: &mut Vec<SignedCheckpointWithSigner>) -> Result<Self, Self::Error> {
+        if signed_checkpoints.is_empty() {
+            return Err(MultisigSignedCheckpointError::EmptySignatures())
+        }
+        // MultisigValidatorManagers expect signatures to be sorted by their signer in ascending
+        // order to prevent duplicates
+        signed_checkpoints.sort_by_key(|c| c.signer);
+        let signatures = signed_checkpoints.iter().map(|c| c.signed_checkpoint.signature).collect();
+
+        Ok(
+            MultisigSignedCheckpoint {
+                // Assume all signed_checkpoints are for the same checkpoint
+                checkpoint: signed_checkpoints[0].signed_checkpoint.checkpoint,
+                signatures,
+            }
+        )
+    }
+}
+
+impl MultisigCheckpointSyncer {
+    /// Constructor
+    pub fn new(threshold: usize, checkpoint_syncers: HashMap<Address, CheckpointSyncers>) -> Self {
+        MultisigSyncer {
+            threshold,
+            checkpoint_syncers
+        }
+    }
+
+    /// Fetches a checkpoint if there is a quorum.
+    /// Returns Ok(None) if there is no quorum.
+    async fn fetch_checkpoint(&self, index: u32) -> Result<Option<MultisigSignedCheckpoint>> {
+        let validator_count = self.checkpoint_syncers.len();
+
+        // Keeps track of signed validator checkpoints for a particular root.
+        // In practice, it's likely that validators will all sign the same root for a
+        // particular index, but we'd like to be robust to this not being the case
+        let mut signed_checkpoints_per_root: HashMap<H256, Vec<SignedCheckpointWithSigner>> = HashMap::new();
+
+        for validator in self.checkpoint_syncers.values() {
+            // Gracefully ignore an error fetching the checkpoint from a validator's checkpoint syncer,
+            // which can happen if the validator has not signed the checkpoint at `index`.
+            match validator.checkpoint_syncer.fetch_checkpoint(index).await {
+                Ok(opt_signed_checkpoint) => {
+                    if let Some(signed_checkpoint) = opt_signed_checkpoint {
+                        // If the signed checkpoint is for a different index, ignore it
+                        if signed_checkpoint.checkpoint.index != index {
+                            continue;
+                        }
+                        // Ensure that the signature is actually by a validator
+                        let signer = signed_checkpoint.recover()?;
+                        if !self.checkpoint_syncers.contains_key(&signer) {
+                            continue;
+                        }
+                        
+                        // Insert the SignedCheckpointWithSigner into signed_checkpoints_per_root
+                        let signed_checkpoint_with_signer = SignedCheckpointWithSigner {
+                            signer: signer,
+                            signed_checkpoint: signed_checkpoint,
+                        };
+                        let root = signed_checkpoint_with_signer.signed_checkpoint.checkpoint.root;
+        
+                        let signature_count = match signed_checkpoints_per_root.entry(root) {
+                            Entry::Occupied(mut entry) => {
+                                let vec = entry.get_mut();
+                                vec.push(signed_checkpoint_with_signer);
+                                vec.len()
+                            },
+                            Entry::Vacant(entry) => {
+                                entry.insert(vec![signed_checkpoint_with_signer]);
+                                1 // length of 1
+                            },
+                        };
+                        // If we've hit a quorum, create a MultisigSignedCheckpoint
+                        if signature_count >= self.threshold {
+                            if let Some(signed_checkpoints) = signed_checkpoints_per_root.get_mut(&root) {
+                                return Ok(
+                                    Some(
+                                        MultisigSignedCheckpoint::try_from(signed_checkpoints)?
+                                    )
+                                );
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        return Ok(None);
+    }
+
+    /// Attempts to get the latest index with a quorum of signatures among validators.
+    /// First iterates through the `latest_index` of each validator's checkpoint syncer,
+    /// looking for the highest index that >= `threshold` validators have returned.
+    /// If there isn't a quorum found this way, each 
+    async fn latest_index(&self) -> Result<Option<u32>> {
+        // Get the latest_index from each validator's checkpoint syncer.
+        let mut latest_indices = Vec::with_capacity(self.checkpoint_syncers.len());
+        for validator in self.checkpoint_syncers.values() {
+            match validator.checkpoint_syncer.latest_index().await? {
+                Some(index) => {
+                    latest_indices.push(index);
+                },
+                _ => {},
+            }
+        }
+        // Sort in descending order to iterate through higher indices first.
+        latest_indices.sort_by(|a, b| b.cmp(a));
+
+
+        let mut last_processed_index = 0;
+
+        // Try to find a quorum among the latest indices
+        let mut index_count = 0;
+        for latest_index in &latest_indices {
+            if *latest_index != last_processed_index {
+                last_processed_index = *latest_index;
+                index_count = 1;
+            } else {
+                index_count += 1;
+            }
+            
+            // If we've found a quorum, return it
+            if index_count >= self.threshold {
+                return Ok(Some(last_processed_index));
+            }
+        }
+
+        // If we didn't find a quorum simply among latest_index responses,
+        // search for a quorum by trying to fetch checkpoints.
+
+        last_processed_index = 0;
+        for latest_index in &latest_indices {
+            // Don't try to fetch a checkpoint for the same index multiple times
+            if *latest_index == last_processed_index {
+                continue;
+            }
+            last_processed_index = *latest_index;
+
+            if let Some(_) = self.fetch_checkpoint(last_processed_index).await? {
+                return Ok(Some(last_processed_index));
+            }
+        }
+        Ok(None)
+    }
+}

--- a/rust/abacus-base/src/types/multisig.rs
+++ b/rust/abacus-base/src/types/multisig.rs
@@ -26,7 +26,7 @@ impl MultisigCheckpointSyncer {
         }
     }
 
-    /// Fetches a checkpoint suitable for a multisig validator manager if there is a quorum.
+    /// Fetches a MultisigSignedCheckpoint if there is a quorum.
     /// Returns Ok(None) if there is no quorum.
     pub async fn fetch_checkpoint(&self, index: u32) -> Result<Option<MultisigSignedCheckpoint>> {
         // Keeps track of signed validator checkpoints for a particular root.
@@ -73,8 +73,7 @@ impl MultisigCheckpointSyncer {
                     };
                     // If we've hit a quorum, create a MultisigSignedCheckpoint
                     if signature_count >= self.threshold {
-                        if let Some(signed_checkpoints) = signed_checkpoints_per_root.get_mut(&root)
-                        {
+                        if let Some(signed_checkpoints) = signed_checkpoints_per_root.get(&root) {
                             return Ok(Some(MultisigSignedCheckpoint::try_from(
                                 signed_checkpoints,
                             )?));

--- a/rust/abacus-base/src/types/multisig.rs
+++ b/rust/abacus-base/src/types/multisig.rs
@@ -9,6 +9,7 @@ use color_eyre::Result;
 use crate::{CheckpointSyncer, CheckpointSyncers};
 
 /// Fetches signed checkpoints from multiple validators to create MultisigSignedCheckpoints
+#[derive(Clone, Debug)]
 pub struct MultisigCheckpointSyncer {
     /// The quorum threshold
     threshold: usize,
@@ -35,9 +36,9 @@ struct SignedCheckpointWithSigner {
 /// A checkpoint and multiple signatures
 pub struct MultisigSignedCheckpoint {
     /// The checkpoint
-    checkpoint: Checkpoint,
+    pub checkpoint: Checkpoint,
     /// ECDSA signatures over the checkpoint, sorted in ascending order by their signer's address
-    signatures: Vec<Signature>,
+    pub signatures: Vec<Signature>,
 }
 
 impl TryFrom<&mut Vec<SignedCheckpointWithSigner>> for MultisigSignedCheckpoint {
@@ -77,7 +78,7 @@ impl MultisigCheckpointSyncer {
 
     /// Fetches a checkpoint suitable for a multisig validator manager if there is a quorum.
     /// Returns Ok(None) if there is no quorum.
-    async fn fetch_checkpoint(&self, index: u32) -> Result<Option<MultisigSignedCheckpoint>> {
+    pub async fn fetch_checkpoint(&self, index: u32) -> Result<Option<MultisigSignedCheckpoint>> {
         // Keeps track of signed validator checkpoints for a particular root.
         // In practice, it's likely that validators will all sign the same root for a
         // particular index, but we'd like to be robust to this not being the case
@@ -145,7 +146,7 @@ impl MultisigCheckpointSyncer {
     /// Note it's possible for both strategies for finding the latest index to not find a quorum.
     /// A more robust implementation should be considered in the future that indexes historical
     /// checkpoint indices.
-    async fn latest_index(&self) -> Result<Option<u32>> {
+    pub async fn latest_index(&self) -> Result<Option<u32>> {
         // Get the latest_index from each validator's checkpoint syncer.
         let mut latest_indices = Vec::with_capacity(self.checkpoint_syncers.len());
         for checkpoint_syncer in self.checkpoint_syncers.values() {

--- a/rust/abacus-base/src/types/multisig.rs
+++ b/rust/abacus-base/src/types/multisig.rs
@@ -68,7 +68,7 @@ impl MultisigCheckpointSyncer {
         }
     }
 
-    /// Fetches a checkpoint if there is a quorum.
+    /// Fetches a checkpoint suitable for a multisig validator manager if there is a quorum.
     /// Returns Ok(None) if there is no quorum.
     async fn fetch_checkpoint(&self, index: u32) -> Result<Option<MultisigSignedCheckpoint>> {
         let validator_count = self.checkpoint_syncers.len();
@@ -138,7 +138,11 @@ impl MultisigCheckpointSyncer {
     /// Attempts to get the latest index with a quorum of signatures among validators.
     /// First iterates through the `latest_index` of each validator's checkpoint syncer,
     /// looking for the highest index that >= `threshold` validators have returned.
-    /// If there isn't a quorum found this way, each
+    /// If there isn't a quorum found this way, each unique index from the highest -> lowest
+    /// is checked for a quorum of signed checkpoints using `fetch_checkpoint`.
+    /// Note it's possible for both strategies for finding the latest index to not find a quorum.
+    /// A more robust implementation should be considered in the future that indexes historical
+    /// checkpoint indices.
     async fn latest_index(&self) -> Result<Option<u32>> {
         // Get the latest_index from each validator's checkpoint syncer.
         let mut latest_indices = Vec::with_capacity(self.checkpoint_syncers.len());

--- a/rust/abacus-base/src/validator_manager.rs
+++ b/rust/abacus-base/src/validator_manager.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use ethers::types::Address;
 
 use abacus_core::{
     ChainCommunicationError, InboxValidatorManager, MultisigSignedCheckpoint, TxOutcome,
@@ -20,22 +21,23 @@ impl InboxValidatorManager for InboxValidatorManagerVariants {
     /// Submit a signed checkpoint for inclusion
     async fn submit_checkpoint(
         &self,
+        inbox: Address,
         multisig_signed_checkpoint: &MultisigSignedCheckpoint,
     ) -> Result<TxOutcome, ChainCommunicationError> {
         match self {
             InboxValidatorManagerVariants::Ethereum(validator_manager) => {
                 validator_manager
-                    .submit_checkpoint(multisig_signed_checkpoint)
+                    .submit_checkpoint(inbox, multisig_signed_checkpoint)
                     .await
             }
             InboxValidatorManagerVariants::Mock(mock_validator_manager) => {
                 mock_validator_manager
-                    .submit_checkpoint(multisig_signed_checkpoint)
+                    .submit_checkpoint(inbox, multisig_signed_checkpoint)
                     .await
             }
             InboxValidatorManagerVariants::Other(validator_manager) => {
                 validator_manager
-                    .submit_checkpoint(multisig_signed_checkpoint)
+                    .submit_checkpoint(inbox, multisig_signed_checkpoint)
                     .await
             }
         }

--- a/rust/abacus-base/src/validator_manager.rs
+++ b/rust/abacus-base/src/validator_manager.rs
@@ -1,5 +1,4 @@
 use async_trait::async_trait;
-use ethers::types::Address;
 use std::sync::Arc;
 
 use abacus_core::{
@@ -46,23 +45,22 @@ impl InboxValidatorManager for InboxValidatorManagerVariants {
     /// Submit a signed checkpoint for inclusion
     async fn submit_checkpoint(
         &self,
-        inbox: Address,
         multisig_signed_checkpoint: &MultisigSignedCheckpoint,
     ) -> Result<TxOutcome, ChainCommunicationError> {
         match self {
             InboxValidatorManagerVariants::Ethereum(validator_manager) => {
                 validator_manager
-                    .submit_checkpoint(inbox, multisig_signed_checkpoint)
+                    .submit_checkpoint(multisig_signed_checkpoint)
                     .await
             }
             InboxValidatorManagerVariants::Mock(mock_validator_manager) => {
                 mock_validator_manager
-                    .submit_checkpoint(inbox, multisig_signed_checkpoint)
+                    .submit_checkpoint(multisig_signed_checkpoint)
                     .await
             }
             InboxValidatorManagerVariants::Other(validator_manager) => {
                 validator_manager
-                    .submit_checkpoint(inbox, multisig_signed_checkpoint)
+                    .submit_checkpoint(multisig_signed_checkpoint)
                     .await
             }
         }

--- a/rust/abacus-base/src/validator_manager.rs
+++ b/rust/abacus-base/src/validator_manager.rs
@@ -1,9 +1,34 @@
 use async_trait::async_trait;
 use ethers::types::Address;
+use std::sync::Arc;
 
 use abacus_core::{
     ChainCommunicationError, InboxValidatorManager, MultisigSignedCheckpoint, TxOutcome,
 };
+
+#[derive(Debug, Clone)]
+/// Arc wrapper for InboxValidatorManagerVariants enum
+pub struct InboxValidatorManagers(Arc<InboxValidatorManagerVariants>);
+
+impl From<InboxValidatorManagerVariants> for InboxValidatorManagers {
+    fn from(inbox_validator_managers: InboxValidatorManagerVariants) -> Self {
+        Self(Arc::new(inbox_validator_managers))
+    }
+}
+
+impl std::ops::Deref for InboxValidatorManagers {
+    type Target = Arc<InboxValidatorManagerVariants>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl std::ops::DerefMut for InboxValidatorManagers {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
 
 /// InboxValidatorManager type
 #[derive(Debug)]

--- a/rust/abacus-base/src/validator_manager.rs
+++ b/rust/abacus-base/src/validator_manager.rs
@@ -1,0 +1,43 @@
+use async_trait::async_trait;
+
+use abacus_core::{
+    ChainCommunicationError, InboxValidatorManager, MultisigSignedCheckpoint, TxOutcome,
+};
+
+/// InboxValidatorManager type
+#[derive(Debug)]
+pub enum InboxValidatorManagerVariants {
+    /// Ethereum InboxValidatorManager contract
+    Ethereum(Box<dyn InboxValidatorManager>),
+    /// Mock InboxValidatorManager contract
+    Mock(Box<dyn InboxValidatorManager>),
+    /// Other InboxValidatorManager variant
+    Other(Box<dyn InboxValidatorManager>),
+}
+
+#[async_trait]
+impl InboxValidatorManager for InboxValidatorManagerVariants {
+    /// Submit a signed checkpoint for inclusion
+    async fn submit_checkpoint(
+        &self,
+        multisig_signed_checkpoint: &MultisigSignedCheckpoint,
+    ) -> Result<TxOutcome, ChainCommunicationError> {
+        match self {
+            InboxValidatorManagerVariants::Ethereum(validator_manager) => {
+                validator_manager
+                    .submit_checkpoint(multisig_signed_checkpoint)
+                    .await
+            }
+            InboxValidatorManagerVariants::Mock(mock_validator_manager) => {
+                mock_validator_manager
+                    .submit_checkpoint(multisig_signed_checkpoint)
+                    .await
+            }
+            InboxValidatorManagerVariants::Other(validator_manager) => {
+                validator_manager
+                    .submit_checkpoint(multisig_signed_checkpoint)
+                    .await
+            }
+        }
+    }
+}

--- a/rust/abacus-core/src/traits/inbox.rs
+++ b/rust/abacus-core/src/traits/inbox.rs
@@ -5,7 +5,7 @@ use ethers::core::types::H256;
 use crate::{
     accumulator::merkle::Proof,
     traits::{AbacusCommon, ChainCommunicationError, TxOutcome},
-    AbacusMessage, MessageStatus, SignedCheckpoint,
+    AbacusMessage, MessageStatus,
 };
 
 /// Interface for on-chain inboxes
@@ -29,11 +29,4 @@ pub trait Inbox: AbacusCommon + Send + Sync + std::fmt::Debug {
 
     /// Fetch the status of a message
     async fn message_status(&self, leaf: H256) -> Result<MessageStatus, ChainCommunicationError>;
-
-    /// Submit a signed checkpoint for inclusion
-    /// Mocks already have a function called checkpoint
-    async fn submit_checkpoint(
-        &self,
-        signed_checkpoint: &SignedCheckpoint,
-    ) -> Result<TxOutcome, ChainCommunicationError>;
 }

--- a/rust/abacus-core/src/traits/mod.rs
+++ b/rust/abacus-core/src/traits/mod.rs
@@ -4,6 +4,7 @@ mod inbox;
 mod indexer;
 mod message;
 mod outbox;
+mod validator_manager;
 
 use async_trait::async_trait;
 use color_eyre::Result;
@@ -22,6 +23,7 @@ pub use inbox::*;
 pub use indexer::*;
 pub use message::*;
 pub use outbox::*;
+pub use validator_manager::*;
 
 /// The result of a transaction
 #[derive(Debug, Clone, Copy)]

--- a/rust/abacus-core/src/traits/validator_manager.rs
+++ b/rust/abacus-core/src/traits/validator_manager.rs
@@ -1,6 +1,5 @@
 use async_trait::async_trait;
 use color_eyre::Result;
-use ethers::types::Address;
 
 use crate::{
     traits::{ChainCommunicationError, TxOutcome},
@@ -14,7 +13,6 @@ pub trait InboxValidatorManager: Send + Sync + std::fmt::Debug {
     /// Mocks already have a function called checkpoint
     async fn submit_checkpoint(
         &self,
-        inbox: Address,
         multisig_signed_checkpoint: &MultisigSignedCheckpoint,
     ) -> Result<TxOutcome, ChainCommunicationError>;
 }

--- a/rust/abacus-core/src/traits/validator_manager.rs
+++ b/rust/abacus-core/src/traits/validator_manager.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 use color_eyre::Result;
+use ethers::types::Address;
 
 use crate::{
     traits::{ChainCommunicationError, TxOutcome},
@@ -13,6 +14,7 @@ pub trait InboxValidatorManager: Send + Sync + std::fmt::Debug {
     /// Mocks already have a function called checkpoint
     async fn submit_checkpoint(
         &self,
+        inbox: Address,
         multisig_signed_checkpoint: &MultisigSignedCheckpoint,
     ) -> Result<TxOutcome, ChainCommunicationError>;
 }

--- a/rust/abacus-core/src/traits/validator_manager.rs
+++ b/rust/abacus-core/src/traits/validator_manager.rs
@@ -1,0 +1,18 @@
+use async_trait::async_trait;
+use color_eyre::Result;
+
+use crate::{
+    traits::{ChainCommunicationError, TxOutcome},
+    MultisigSignedCheckpoint,
+};
+
+/// Interface for an InboxValidatorManager
+#[async_trait]
+pub trait InboxValidatorManager: Send + Sync + std::fmt::Debug {
+    /// Submit a signed checkpoint for inclusion
+    /// Mocks already have a function called checkpoint
+    async fn submit_checkpoint(
+        &self,
+        multisig_signed_checkpoint: &MultisigSignedCheckpoint,
+    ) -> Result<TxOutcome, ChainCommunicationError>;
+}

--- a/rust/abacus-core/src/types/checkpoint.rs
+++ b/rust/abacus-core/src/types/checkpoint.rs
@@ -187,3 +187,53 @@ impl SignedCheckpoint {
             .verify(self.checkpoint.prepended_hash(), signer)?)
     }
 }
+
+/// A individiual signed checkpoint with the recovered signer
+pub struct SignedCheckpointWithSigner {
+    /// The recovered signer
+    pub signer: Address,
+    /// The signed checkpoint
+    pub signed_checkpoint: SignedCheckpoint,
+}
+
+/// A checkpoint and multiple signatures
+pub struct MultisigSignedCheckpoint {
+    /// The checkpoint
+    pub checkpoint: Checkpoint,
+    /// ECDSA signatures over the checkpoint, sorted in ascending order by their signer's address
+    pub signatures: Vec<Signature>,
+}
+
+/// Error types for MultisigSignedCheckpoint
+#[derive(Debug, thiserror::Error)]
+pub enum MultisigSignedCheckpointError {
+    /// The signed checkpoint has no signatures
+    #[error("Multisig signed checkpoint has no signatures")]
+    EmptySignatures(),
+}
+
+impl TryFrom<&mut Vec<SignedCheckpointWithSigner>> for MultisigSignedCheckpoint {
+    type Error = MultisigSignedCheckpointError;
+
+    /// Given multiple signed checkpoints with their signer, creates a MultisigSignedCheckpoint
+    fn try_from(
+        signed_checkpoints: &mut Vec<SignedCheckpointWithSigner>,
+    ) -> Result<Self, Self::Error> {
+        if signed_checkpoints.is_empty() {
+            return Err(MultisigSignedCheckpointError::EmptySignatures());
+        }
+        // MultisigValidatorManagers expect signatures to be sorted by their signer in ascending
+        // order to prevent duplicates
+        signed_checkpoints.sort_by_key(|c| c.signer);
+        let signatures = signed_checkpoints
+            .iter()
+            .map(|c| c.signed_checkpoint.signature)
+            .collect();
+
+        Ok(MultisigSignedCheckpoint {
+            // Assume all signed_checkpoints are for the same checkpoint
+            checkpoint: signed_checkpoints[0].signed_checkpoint.checkpoint,
+            signatures,
+        })
+    }
+}

--- a/rust/abacus-core/src/types/checkpoint.rs
+++ b/rust/abacus-core/src/types/checkpoint.rs
@@ -198,6 +198,7 @@ pub struct SignedCheckpointWithSigner {
 }
 
 /// A checkpoint and multiple signatures
+#[derive(Debug)]
 pub struct MultisigSignedCheckpoint {
     /// The checkpoint
     pub checkpoint: Checkpoint,

--- a/rust/abacus-test/src/mocks/inbox.rs
+++ b/rust/abacus-test/src/mocks/inbox.rs
@@ -75,13 +75,6 @@ impl Inbox for MockInboxContract {
     async fn message_status(&self, leaf: H256) -> Result<MessageStatus, ChainCommunicationError> {
         self._message_status(leaf)
     }
-
-    async fn submit_checkpoint(
-        &self,
-        signed_checkpoint: &SignedCheckpoint,
-    ) -> Result<TxOutcome, ChainCommunicationError> {
-        self._checkpoint(signed_checkpoint)
-    }
 }
 
 #[async_trait]

--- a/rust/agents/kathy/src/kathy.rs
+++ b/rust/agents/kathy/src/kathy.rs
@@ -108,9 +108,11 @@ impl Kathy {
 
     pub fn run(&self) -> Instrumented<JoinHandle<Result<()>>> {
         let inbox_tasks: Vec<Instrumented<JoinHandle<Result<()>>>> = self
-            .inboxes()
+            .inbox_contracts()
             .iter()
-            .map(|(inbox_name, inbox)| self.wrap_inbox_run(inbox_name, inbox.clone()))
+            .map(|(inbox_name, inbox_contracts)| {
+                self.wrap_inbox_run(inbox_name, inbox_contracts.inbox.clone())
+            })
             .collect();
         self.run_all(inbox_tasks)
     }

--- a/rust/agents/kathy/src/kathy.rs
+++ b/rust/agents/kathy/src/kathy.rs
@@ -108,7 +108,7 @@ impl Kathy {
 
     pub fn run(&self) -> Instrumented<JoinHandle<Result<()>>> {
         let inbox_tasks: Vec<Instrumented<JoinHandle<Result<()>>>> = self
-            .inbox_contracts()
+            .inboxes()
             .iter()
             .map(|(inbox_name, inbox_contracts)| {
                 self.wrap_inbox_run(inbox_name, inbox_contracts.inbox.clone())

--- a/rust/agents/relayer/src/checkpoint_relayer.rs
+++ b/rust/agents/relayer/src/checkpoint_relayer.rs
@@ -1,4 +1,4 @@
-use std::{time::Duration};
+use std::time::Duration;
 
 use abacus_base::{InboxContracts, MultisigCheckpointSyncer};
 use abacus_core::{db::AbacusDB, AbacusCommon, CommittedMessage, Inbox, InboxValidatorManager};
@@ -92,7 +92,8 @@ impl CheckpointRelayer {
             );
 
             self.prover_sync.update_from_batch(&batch)?;
-            self.inbox_contracts.validator_manager
+            self.inbox_contracts
+                .validator_manager
                 .submit_checkpoint(&latest_signed_checkpoint)
                 .await?;
 
@@ -102,7 +103,12 @@ impl CheckpointRelayer {
                     match self.prover_sync.get_proof(message.leaf_index) {
                         Ok(proof) => {
                             // Ignore errors and expect the lagged message processor to retry
-                            match self.inbox_contracts.inbox.prove_and_process(&message.message, &proof).await {
+                            match self
+                                .inbox_contracts
+                                .inbox
+                                .prove_and_process(&message.message, &proof)
+                                .await
+                            {
                                 Ok(outcome) => {
                                     info!(txHash=?outcome.txid, leaf_index=message.leaf_index, "CheckpointRelayer processed message")
                                 }
@@ -129,7 +135,8 @@ impl CheckpointRelayer {
     pub(crate) fn spawn(mut self) -> Instrumented<JoinHandle<Result<()>>> {
         let span = info_span!("CheckpointRelayer");
         tokio::spawn(async move {
-            let latest_inbox_checkpoint = self.inbox_contracts.inbox.latest_checkpoint(None).await?;
+            let latest_inbox_checkpoint =
+                self.inbox_contracts.inbox.latest_checkpoint(None).await?;
             let mut onchain_checkpoint_index = latest_inbox_checkpoint.index;
             // Checkpoints are 1-indexed, while leaves are 0-indexed
             let mut next_inbox_leaf_index = onchain_checkpoint_index;

--- a/rust/agents/relayer/src/checkpoint_relayer.rs
+++ b/rust/agents/relayer/src/checkpoint_relayer.rs
@@ -88,7 +88,7 @@ impl CheckpointRelayer {
             let batch = MessageBatch::new(
                 messages,
                 onchain_checkpoint_index,
-                latest_signed_checkpoint.checkpoint.clone(),
+                latest_signed_checkpoint.checkpoint,
             );
 
             self.prover_sync.update_from_batch(&batch)?;

--- a/rust/agents/relayer/src/relayer.rs
+++ b/rust/agents/relayer/src/relayer.rs
@@ -47,7 +47,7 @@ impl Relayer {
                     "Number of checkpoints relayed from given outbox to inbox",
                     &["outbox", "inbox", "agent"],
                 )
-                .expect("processor metric already registered -- should have be a singleton"),
+                .expect("processor metric already registered -- should be a singleton"),
         );
 
         Self {
@@ -101,6 +101,7 @@ impl Relayer {
         );
         sync
     }
+
     fn run_inbox(&self, inbox: Arc<CachingInbox>) -> Instrumented<JoinHandle<Result<()>>> {
         let db = self.outbox().db();
         let checkpoint_relayer = CheckpointRelayer::new(

--- a/rust/agents/relayer/src/relayer.rs
+++ b/rust/agents/relayer/src/relayer.rs
@@ -147,7 +147,7 @@ impl Relayer {
 
     pub fn run(&self) -> Instrumented<JoinHandle<Result<()>>> {
         let mut inbox_tasks: Vec<Instrumented<JoinHandle<Result<()>>>> = self
-            .inbox_contracts()
+            .inboxes()
             .iter()
             .map(|(inbox_name, inbox_contracts)| {
                 self.wrap_inbox_run(

--- a/rust/agents/relayer/src/relayer.rs
+++ b/rust/agents/relayer/src/relayer.rs
@@ -103,10 +103,7 @@ impl Relayer {
         sync
     }
 
-    fn run_inbox(
-        &self,
-        inbox_contracts: InboxContracts,
-    ) -> Instrumented<JoinHandle<Result<()>>> {
+    fn run_inbox(&self, inbox_contracts: InboxContracts) -> Instrumented<JoinHandle<Result<()>>> {
         let db = self.outbox().db();
         let checkpoint_relayer = CheckpointRelayer::new(
             self.polling_interval,
@@ -133,9 +130,7 @@ impl Relayer {
         inbox_contracts: InboxContracts,
     ) -> Instrumented<JoinHandle<Result<()>>> {
         let m = format!("Task for inbox named {} failed", inbox_name);
-        let handle = self
-            .run_inbox(inbox_contracts)
-            .in_current_span();
+        let handle = self.run_inbox(inbox_contracts).in_current_span();
         let fut = async move { handle.await?.wrap_err(m) };
 
         tokio::spawn(fut).in_current_span()
@@ -146,10 +141,7 @@ impl Relayer {
             .inboxes()
             .iter()
             .map(|(inbox_name, inbox_contracts)| {
-                self.wrap_inbox_run(
-                    inbox_name,
-                    inbox_contracts.clone(),
-                )
+                self.wrap_inbox_run(inbox_name, inbox_contracts.clone())
             })
             .collect();
         inbox_tasks.push(self.run_contract_sync());

--- a/rust/agents/relayer/src/relayer.rs
+++ b/rust/agents/relayer/src/relayer.rs
@@ -147,10 +147,14 @@ impl Relayer {
 
     pub fn run(&self) -> Instrumented<JoinHandle<Result<()>>> {
         let mut inbox_tasks: Vec<Instrumented<JoinHandle<Result<()>>>> = self
-            .inboxes_and_validator_managers()
+            .inbox_contracts()
             .iter()
-            .map(|(inbox_name, (inbox, validator_manager))| {
-                self.wrap_inbox_run(inbox_name, inbox.clone(), validator_manager.clone())
+            .map(|(inbox_name, inbox_contracts)| {
+                self.wrap_inbox_run(
+                    inbox_name,
+                    inbox_contracts.inbox.clone(),
+                    inbox_contracts.validator_manager.clone(),
+                )
             })
             .collect();
         inbox_tasks.push(self.run_contract_sync());

--- a/rust/agents/relayer/src/settings.rs
+++ b/rust/agents/relayer/src/settings.rs
@@ -11,6 +11,6 @@ decl_settings!(Relayer {
     maxretries: String,
     /// Whether the CheckpointRelayer should try to immediately process messages
     relayermessageprocessing: String,
-    /// The checkpoint syncer configuration
-    checkpointsyncer: abacus_base::CheckpointSyncerConf,
+    /// The multisig checkpoint syncer configuration
+    multisigcheckpointsyncer: abacus_base::MultisigCheckpointSyncerConf,
 });

--- a/rust/agents/validator/src/validator.rs
+++ b/rust/agents/validator/src/validator.rs
@@ -57,10 +57,7 @@ impl Agent for Validator {
         let signer = settings.validator.try_into_signer().await?;
         let reorg_period = settings.reorgperiod.parse().expect("invalid uint");
         let interval = settings.interval.parse().expect("invalid uint");
-        let checkpoint_syncer = settings
-            .checkpointsyncer
-            .try_into_checkpoint_syncer()
-            .await?;
+        let checkpoint_syncer = settings.checkpointsyncer.try_into_checkpoint_syncer()?;
         let core = settings
             .as_ref()
             .try_into_abacus_core(Self::AGENT_NAME)

--- a/rust/chains/abacus-ethereum/abis/Inbox.abi.json
+++ b/rust/chains/abacus-ethereum/abis/Inbox.abi.json
@@ -98,11 +98,6 @@
         "internalType": "uint256",
         "name": "_index",
         "type": "uint256"
-      },
-      {
-        "internalType": "bytes",
-        "name": "_signature",
-        "type": "bytes"
       }
     ],
     "name": "checkpoint",
@@ -349,7 +344,7 @@
     "name": "validatorManager",
     "outputs": [
       {
-        "internalType": "contract IValidatorManager",
+        "internalType": "address",
         "name": "",
         "type": "address"
       }

--- a/rust/chains/abacus-ethereum/abis/InboxValidatorManager.abi.json
+++ b/rust/chains/abacus-ethereum/abis/InboxValidatorManager.abi.json
@@ -1,0 +1,306 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "_remoteDomain",
+        "type": "uint32"
+      },
+      {
+        "internalType": "address[]",
+        "name": "_validators",
+        "type": "address[]"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_threshold",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "validator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "validatorCount",
+        "type": "uint256"
+      }
+    ],
+    "name": "EnrollValidator",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "previousOwner",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "threshold",
+        "type": "uint256"
+      }
+    ],
+    "name": "SetThreshold",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "validator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "validatorCount",
+        "type": "uint256"
+      }
+    ],
+    "name": "UnenrollValidator",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract IInbox",
+        "name": "_inbox",
+        "type": "address"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "_root",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_index",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes[]",
+        "name": "_signatures",
+        "type": "bytes[]"
+      }
+    ],
+    "name": "checkpoint",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "domain",
+    "outputs": [
+      {
+        "internalType": "uint32",
+        "name": "",
+        "type": "uint32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "domainHash",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_validator",
+        "type": "address"
+      }
+    ],
+    "name": "enrollValidator",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_root",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_index",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes[]",
+        "name": "_signatures",
+        "type": "bytes[]"
+      }
+    ],
+    "name": "isQuorum",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_validator",
+        "type": "address"
+      }
+    ],
+    "name": "isValidator",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_threshold",
+        "type": "uint256"
+      }
+    ],
+    "name": "setThreshold",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "threshold",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_validator",
+        "type": "address"
+      }
+    ],
+    "name": "unenrollValidator",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "validatorCount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "validators",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/rust/chains/abacus-ethereum/abis/Outbox.abi.json
+++ b/rust/chains/abacus-ethereum/abis/Outbox.abi.json
@@ -201,7 +201,13 @@
       }
     ],
     "name": "dispatch",
-    "outputs": [],
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
     "stateMutability": "nonpayable",
     "type": "function"
   },
@@ -223,6 +229,30 @@
     "name": "initialize",
     "outputs": [],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "_root",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint256",
+        "name": "_index",
+        "type": "uint256"
+      }
+    ],
+    "name": "isCheckpoint",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -365,7 +395,7 @@
     "name": "validatorManager",
     "outputs": [
       {
-        "internalType": "contract IValidatorManager",
+        "internalType": "address",
         "name": "",
         "type": "address"
       }

--- a/rust/chains/abacus-ethereum/src/inbox.rs
+++ b/rust/chains/abacus-ethereum/src/inbox.rs
@@ -287,18 +287,4 @@ where
             _ => panic!("Bad status from solidity"),
         }
     }
-
-    #[tracing::instrument(err, skip(self), fields(hex_signature = %format!("0x{}", hex::encode(signed_checkpoint.signature.to_vec()))))]
-    async fn submit_checkpoint(
-        &self,
-        signed_checkpoint: &SignedCheckpoint,
-    ) -> Result<TxOutcome, ChainCommunicationError> {
-        let tx = self.contract.checkpoint(
-            signed_checkpoint.checkpoint.root.to_fixed_bytes(),
-            signed_checkpoint.checkpoint.index.into(),
-            signed_checkpoint.signature.to_vec().into(),
-        );
-
-        Ok(report_tx!(tx).into())
-    }
 }

--- a/rust/chains/abacus-ethereum/src/lib.rs
+++ b/rust/chains/abacus-ethereum/src/lib.rs
@@ -22,6 +22,10 @@ mod outbox;
 #[cfg(not(doctest))]
 mod inbox;
 
+/// InboxValidatorManager abi
+#[cfg(not(doctest))]
+mod validator_manager;
+
 /// Ethereum connection configuration
 #[derive(Debug, serde::Deserialize, Clone)]
 #[serde(tag = "type", rename_all = "camelCase")]
@@ -47,7 +51,7 @@ impl Default for Connection {
 }
 
 #[cfg(not(doctest))]
-pub use crate::{inbox::*, outbox::*};
+pub use crate::{inbox::*, outbox::*, validator_manager::*};
 
 #[allow(dead_code)]
 /// A live connection to an ethereum-compatible chain.
@@ -72,6 +76,7 @@ boxed_trait!(
 );
 boxed_trait!(make_outbox, EthereumOutbox, Outbox,);
 boxed_trait!(make_inbox, EthereumInbox, Inbox,);
+boxed_trait!(make_inbox_validator_manager, EthereumInboxValidatorManager, InboxValidatorManager,);
 
 #[async_trait::async_trait]
 impl abacus_core::Chain for Chain {

--- a/rust/chains/abacus-ethereum/src/lib.rs
+++ b/rust/chains/abacus-ethereum/src/lib.rs
@@ -6,7 +6,6 @@
 
 use abacus_core::*;
 use color_eyre::eyre::Result;
-// use ethers::prelude::*;
 use ethers::providers::Middleware;
 use ethers::types::{Address, BlockId, BlockNumber, NameOrAddress, H160};
 use num::Num;

--- a/rust/chains/abacus-ethereum/src/lib.rs
+++ b/rust/chains/abacus-ethereum/src/lib.rs
@@ -6,7 +6,9 @@
 
 use abacus_core::*;
 use color_eyre::eyre::Result;
-use ethers::prelude::*;
+// use ethers::prelude::*;
+use ethers::providers::Middleware;
+use ethers::types::{Address, BlockId, BlockNumber, NameOrAddress, H160};
 use num::Num;
 use std::convert::TryFrom;
 use std::sync::Arc;
@@ -80,6 +82,7 @@ boxed_trait!(
     make_inbox_validator_manager,
     EthereumInboxValidatorManager,
     InboxValidatorManager,
+    inbox_address: Address
 );
 
 #[async_trait::async_trait]

--- a/rust/chains/abacus-ethereum/src/lib.rs
+++ b/rust/chains/abacus-ethereum/src/lib.rs
@@ -76,7 +76,11 @@ boxed_trait!(
 );
 boxed_trait!(make_outbox, EthereumOutbox, Outbox,);
 boxed_trait!(make_inbox, EthereumInbox, Inbox,);
-boxed_trait!(make_inbox_validator_manager, EthereumInboxValidatorManager, InboxValidatorManager,);
+boxed_trait!(
+    make_inbox_validator_manager,
+    EthereumInboxValidatorManager,
+    InboxValidatorManager,
+);
 
 #[async_trait::async_trait]
 impl abacus_core::Chain for Chain {

--- a/rust/chains/abacus-ethereum/src/validator_manager.rs
+++ b/rust/chains/abacus-ethereum/src/validator_manager.rs
@@ -37,6 +37,7 @@ where
     domain: u32,
     name: String,
     provider: Arc<M>,
+    inbox_address: Address,
 }
 
 impl<M> EthereumInboxValidatorManager<M>
@@ -52,6 +53,7 @@ where
             domain,
             address,
         }: &ContractLocator,
+        inbox_address: Address,
     ) -> Self {
         Self {
             contract: Arc::new(EthereumInboxValidatorManagerInternal::new(
@@ -61,6 +63,7 @@ where
             domain: *domain,
             name: name.to_owned(),
             provider,
+            inbox_address,
         }
     }
 }
@@ -73,11 +76,10 @@ where
     // #[tracing::instrument(err, skip(self), fields(hex_signature = %format!("0x{}", hex::encode(multisig_signed_checkpoint.signatures.to_vec()))))]
     async fn submit_checkpoint(
         &self,
-        inbox: Address,
         multisig_signed_checkpoint: &MultisigSignedCheckpoint,
     ) -> Result<TxOutcome, ChainCommunicationError> {
         let tx = self.contract.checkpoint(
-            inbox,
+            self.inbox_address,
             multisig_signed_checkpoint.checkpoint.root.to_fixed_bytes(),
             multisig_signed_checkpoint.checkpoint.index.into(),
             multisig_signed_checkpoint

--- a/rust/chains/abacus-ethereum/src/validator_manager.rs
+++ b/rust/chains/abacus-ethereum/src/validator_manager.rs
@@ -1,0 +1,87 @@
+#![allow(clippy::enum_variant_names)]
+#![allow(missing_docs)]
+
+use abacus_core::{InboxValidatorManager, MultisigSignedCheckpoint};
+use abacus_core::{
+    ChainCommunicationError, ContractLocator, TxOutcome,
+};
+use async_trait::async_trait;
+use color_eyre::Result;
+use ethers::contract::abigen;
+use ethers::core::types::{Address};
+// use tracing::instrument;
+
+use std::sync::Arc;
+
+use crate::report_tx;
+
+abigen!(
+    EthereumInboxValidatorManagerInternal,
+    "./chains/abacus-ethereum/abis/InboxValidatorManager.abi.json",
+);
+
+impl<M> std::fmt::Display for EthereumInboxValidatorManagerInternal<M>
+where
+    M: ethers::providers::Middleware,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+/// A struct that provides access to an Ethereum InboxValidatorManager contract
+#[derive(Debug)]
+pub struct EthereumInboxValidatorManager<M>
+where
+    M: ethers::providers::Middleware,
+{
+    contract: Arc<EthereumInboxValidatorManagerInternal<M>>,
+    domain: u32,
+    name: String,
+    provider: Arc<M>,
+}
+
+impl<M> EthereumInboxValidatorManager<M>
+where
+    M: ethers::providers::Middleware,
+{
+    /// Create a reference to a inbox at a specific Ethereum address on some
+    /// chain
+    pub fn new(
+        provider: Arc<M>,
+        ContractLocator {
+            name,
+            domain,
+            address,
+        }: &ContractLocator,
+    ) -> Self {
+        Self {
+            contract: Arc::new(EthereumInboxValidatorManagerInternal::new(address, provider.clone())),
+            domain: *domain,
+            name: name.to_owned(),
+            provider,
+        }
+    }
+}
+
+#[async_trait]
+impl<M> InboxValidatorManager for EthereumInboxValidatorManager<M>
+where
+    M: ethers::providers::Middleware + 'static,
+{
+    // #[tracing::instrument(err, skip(self), fields(hex_signature = %format!("0x{}", hex::encode(multisig_signed_checkpoint.signatures.to_vec()))))]
+    async fn submit_checkpoint(
+        &self,
+        inbox: Address,
+        multisig_signed_checkpoint: &MultisigSignedCheckpoint,
+    ) -> Result<TxOutcome, ChainCommunicationError> {
+        let tx = self.contract.checkpoint(
+            inbox,
+            multisig_signed_checkpoint.checkpoint.root.to_fixed_bytes(),
+            multisig_signed_checkpoint.checkpoint.index.into(),
+            multisig_signed_checkpoint.signatures.iter().map(|s| s.to_vec().into()).collect(),
+        );
+
+        Ok(report_tx!(tx).into())
+    }
+}

--- a/rust/chains/abacus-ethereum/src/validator_manager.rs
+++ b/rust/chains/abacus-ethereum/src/validator_manager.rs
@@ -1,14 +1,12 @@
 #![allow(clippy::enum_variant_names)]
 #![allow(missing_docs)]
 
+use abacus_core::{ChainCommunicationError, ContractLocator, TxOutcome};
 use abacus_core::{InboxValidatorManager, MultisigSignedCheckpoint};
-use abacus_core::{
-    ChainCommunicationError, ContractLocator, TxOutcome,
-};
 use async_trait::async_trait;
 use color_eyre::Result;
 use ethers::contract::abigen;
-use ethers::core::types::{Address};
+use ethers::core::types::Address;
 // use tracing::instrument;
 
 use std::sync::Arc;
@@ -56,7 +54,10 @@ where
         }: &ContractLocator,
     ) -> Self {
         Self {
-            contract: Arc::new(EthereumInboxValidatorManagerInternal::new(address, provider.clone())),
+            contract: Arc::new(EthereumInboxValidatorManagerInternal::new(
+                address,
+                provider.clone(),
+            )),
             domain: *domain,
             name: name.to_owned(),
             provider,
@@ -79,7 +80,11 @@ where
             inbox,
             multisig_signed_checkpoint.checkpoint.root.to_fixed_bytes(),
             multisig_signed_checkpoint.checkpoint.index.into(),
-            multisig_signed_checkpoint.signatures.iter().map(|s| s.to_vec().into()).collect(),
+            multisig_signed_checkpoint
+                .signatures
+                .iter()
+                .map(|s| s.to_vec().into())
+                .collect(),
         );
 
         Ok(report_tx!(tx).into())

--- a/rust/chains/abacus-ethereum/src/validator_manager.rs
+++ b/rust/chains/abacus-ethereum/src/validator_manager.rs
@@ -7,7 +7,6 @@ use async_trait::async_trait;
 use color_eyre::Result;
 use ethers::contract::abigen;
 use ethers::core::types::Address;
-// use tracing::instrument;
 
 use std::sync::Arc;
 
@@ -73,7 +72,7 @@ impl<M> InboxValidatorManager for EthereumInboxValidatorManager<M>
 where
     M: ethers::providers::Middleware + 'static,
 {
-    // #[tracing::instrument(err, skip(self), fields(hex_signature = %format!("0x{}", hex::encode(multisig_signed_checkpoint.signatures.to_vec()))))]
+    #[tracing::instrument(err, skip(self))]
     async fn submit_checkpoint(
         &self,
         multisig_signed_checkpoint: &MultisigSignedCheckpoint,

--- a/rust/config/test/alfajores_config.json
+++ b/rust/config/test/alfajores_config.json
@@ -1,46 +1,78 @@
 {
   "environment": "test",
   "signers": {},
-  "inboxes": {
-    "kovan": {
-      "address": "0x84eA74d481Ee0A5332c457a4d796187F6Ba67fEB",
-      "domain": "3000",
-      "name": "kovan",
-      "rpcStyle": "ethereum",
-      "connection": {
-        "type": "http",
-        "url": ""
-      }
-    },
-    "mumbai": {
-      "address": "0x5f3f1dBD7B74C6B46e8c44f98792A1dAf8d69154",
-      "domain": "80001",
-      "name": "mumbai",
-      "rpcStyle": "ethereum",
-      "connection": {
-        "type": "http",
-        "url": ""
-      }
-    },
-    "fuji": {
-      "address": "0x21dF544947ba3E8b3c32561399E88B52Dc8b2823",
-      "domain": "43113",
-      "name": "fuji",
-      "rpcStyle": "ethereum",
-      "connection": {
-        "type": "http",
-        "url": ""
-      }
-    }
-  },
   "outbox": {
-    "address": "0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6",
+    "address": "0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9",
     "domain": "1000",
     "name": "alfajores",
     "rpcStyle": "ethereum",
     "connection": {
       "type": "http",
       "url": ""
+    }
+  },
+  "inboxes": {
+    "kovan": {
+      "domain": "3000",
+      "name": "kovan",
+      "rpcStyle": "ethereum",
+      "connection": {
+        "type": "http",
+        "url": ""
+      },
+      "address": "0x84eA74d481Ee0A5332c457a4d796187F6Ba67fEB"
+    },
+    "mumbai": {
+      "domain": "80001",
+      "name": "mumbai",
+      "rpcStyle": "ethereum",
+      "connection": {
+        "type": "http",
+        "url": ""
+      },
+      "address": "0xb7278A61aa25c888815aFC32Ad3cC52fF24fE575"
+    },
+    "fuji": {
+      "domain": "43113",
+      "name": "fuji",
+      "rpcStyle": "ethereum",
+      "connection": {
+        "type": "http",
+        "url": ""
+      },
+      "address": "0xD8a5a9b31c3C0232E196d518E89Fd8bF83AcAd43"
+    }
+  },
+  "inboxValidatorManagers": {
+    "kovan": {
+      "domain": "3000",
+      "name": "kovan",
+      "rpcStyle": "ethereum",
+      "connection": {
+        "type": "http",
+        "url": ""
+      },
+      "address": "0x67d269191c92Caf3cD7723F116c85e6E9bf55933"
+    },
+    "mumbai": {
+      "domain": "80001",
+      "name": "mumbai",
+      "rpcStyle": "ethereum",
+      "connection": {
+        "type": "http",
+        "url": ""
+      },
+      "address": "0x4c5859f0F772848b2D91F1D83E2Fe57935348029"
+    },
+    "fuji": {
+      "domain": "43113",
+      "name": "fuji",
+      "rpcStyle": "ethereum",
+      "connection": {
+        "type": "http",
+        "url": ""
+      },
+      "address": "0x4C4a2f8c81640e47606d3fd77B353E87Ba015584"
     }
   },
   "tracing": {

--- a/rust/config/test/alfajores_config.json
+++ b/rust/config/test/alfajores_config.json
@@ -2,7 +2,9 @@
   "environment": "test",
   "signers": {},
   "outbox": {
-    "address": "0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9",
+    "addresses": {
+      "outbox": "0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9"
+    },
     "domain": "1000",
     "name": "alfajores",
     "rpcStyle": "ethereum",
@@ -20,7 +22,10 @@
         "type": "http",
         "url": ""
       },
-      "address": "0x84eA74d481Ee0A5332c457a4d796187F6Ba67fEB"
+      "addresses": {
+        "inbox": "0x84eA74d481Ee0A5332c457a4d796187F6Ba67fEB",
+        "validatorManager": "0x67d269191c92Caf3cD7723F116c85e6E9bf55933"
+      }
     },
     "mumbai": {
       "domain": "80001",
@@ -30,7 +35,10 @@
         "type": "http",
         "url": ""
       },
-      "address": "0xb7278A61aa25c888815aFC32Ad3cC52fF24fE575"
+      "addresses": {
+        "inbox": "0xb7278A61aa25c888815aFC32Ad3cC52fF24fE575",
+        "validatorManager": "0x4c5859f0F772848b2D91F1D83E2Fe57935348029"
+      }
     },
     "fuji": {
       "domain": "43113",
@@ -40,39 +48,10 @@
         "type": "http",
         "url": ""
       },
-      "address": "0xD8a5a9b31c3C0232E196d518E89Fd8bF83AcAd43"
-    }
-  },
-  "inboxValidatorManagers": {
-    "kovan": {
-      "domain": "3000",
-      "name": "kovan",
-      "rpcStyle": "ethereum",
-      "connection": {
-        "type": "http",
-        "url": ""
-      },
-      "address": "0x67d269191c92Caf3cD7723F116c85e6E9bf55933"
-    },
-    "mumbai": {
-      "domain": "80001",
-      "name": "mumbai",
-      "rpcStyle": "ethereum",
-      "connection": {
-        "type": "http",
-        "url": ""
-      },
-      "address": "0x4c5859f0F772848b2D91F1D83E2Fe57935348029"
-    },
-    "fuji": {
-      "domain": "43113",
-      "name": "fuji",
-      "rpcStyle": "ethereum",
-      "connection": {
-        "type": "http",
-        "url": ""
-      },
-      "address": "0x4C4a2f8c81640e47606d3fd77B353E87Ba015584"
+      "addresses": {
+        "inbox": "0xD8a5a9b31c3C0232E196d518E89Fd8bF83AcAd43",
+        "validatorManager": "0x4C4a2f8c81640e47606d3fd77B353E87Ba015584"
+      }
     }
   },
   "tracing": {

--- a/rust/tools/balance-exporter/src/main.rs
+++ b/rust/tools/balance-exporter/src/main.rs
@@ -8,8 +8,11 @@ use human_panic::setup_panic;
 use tokio::time::Instant;
 
 #[derive(serde::Deserialize, Debug)]
+struct Contract(String);
+
+#[derive(serde::Deserialize, Debug)]
 struct Input {
-    contracts: Vec<ChainSetup>,
+    contracts: Vec<ChainSetup<Contract>>,
 }
 
 struct Sample {
@@ -110,13 +113,13 @@ async fn main() -> color_eyre::Result<()> {
         for (ix, res) in results.balances.into_iter().enumerate() {
             let ChainSetup {
                 name: network,
-                address,
+                addresses,
                 ..
             } = &setup.contracts[ix];
             match res {
                 Ok(s) => {
                     // TODO: export metric
-                    println!("{} {} = {}", network, address, s);
+                    println!("{} {} = {}", network, addresses.0, s);
                 }
                 Err(e) => {
                     eprintln!("Error while querying {:?}: {}", setup.contracts[ix], e);
@@ -146,7 +149,7 @@ async fn mainnet_works() {
                 chain: abacus_base::chains::ChainConf::Ethereum(abacus_ethereum::Connection::Ws {
                     url: "wss://main-light.eth.linkpool.io/ws".into(),
                 }),
-                address: "0xcEc158A719d11005Bd9339865965bed938BEafA3".into(),
+                addresses: Contract("0xcEc158A719d11005Bd9339865965bed938BEafA3".into()),
                 disabled: None,
             }],
         },

--- a/typescript/infra/scripts/output-agent-env-vars.ts
+++ b/typescript/infra/scripts/output-agent-env-vars.ts
@@ -15,22 +15,17 @@ async function main() {
     .describe('f', 'filepath')
     .require('f').argv;
 
-  console.log('a')
-
   const environment = await getEnvironment();
   const agentConfig = await getAgentConfig(environment);
   const domainNames = await getDomainNames(environment);
-  console.log('b')
   const envVars = await getAgentEnvVars(
     argv.c,
     argv.r,
     agentConfig,
     domainNames,
   );
-  console.log('c')
 
   await writeFile(argv.f, envVars.join('\n'));
-  console.log('d')
 }
 
 main().then(console.log).catch(console.error);

--- a/typescript/infra/scripts/output-agent-env-vars.ts
+++ b/typescript/infra/scripts/output-agent-env-vars.ts
@@ -15,17 +15,22 @@ async function main() {
     .describe('f', 'filepath')
     .require('f').argv;
 
+  console.log('a')
+
   const environment = await getEnvironment();
   const agentConfig = await getAgentConfig(environment);
   const domainNames = await getDomainNames(environment);
+  console.log('b')
   const envVars = await getAgentEnvVars(
     argv.c,
     argv.r,
     agentConfig,
     domainNames,
   );
+  console.log('c')
 
   await writeFile(argv.f, envVars.join('\n'));
+  console.log('d')
 }
 
 main().then(console.log).catch(console.error);

--- a/typescript/infra/src/agents/index.ts
+++ b/typescript/infra/src/agents/index.ts
@@ -166,29 +166,8 @@ export async function getAgentEnvVars(
 
     if (role === KEY_ROLE_ENUM.Relayer) {
       envVars.push(
-        `OPT_RELAYER_POLLINGINTERVAL=${valueDict.abacus.relayer.pollingInterval}`,
+        `OPT_RELAYER_INTERVAL=${valueDict.abacus.relayer.pollingInterval}`,
       );
-
-      // TODO change
-      envVars.push(
-        `OPT_RELAYER_SUBMISSIONLATENCY=${valueDict.abacus.relayer.pollingInterval}`,
-      );
-
-      // TODO change
-      envVars.push(
-        `OPT_RELAYER_MAXRETRIES=${valueDict.abacus.relayer.pollingInterval}`,
-      );
-
-          /// The polling interval to check for new checkpoints in seconds
-    // pollinginterval: String,
-    // /// The minimum latency in seconds between two relayed checkpoints on the inbox
-    // submissionlatency: String,
-    // /// The maxinmum number of times a processor will try to process a message
-    // maxretries: String,
-    // /// Whether the CheckpointRelayer should try to immediately process messages
-    // relayermessageprocessing: String,
-    // /// The multisig checkpoint syncer configuration
-    // multisigcheckpointsyncer: abacus_base::MultisigCheckpointSyncerConf,
     }
   } catch (error) {
     // This happens if you don't have a result type

--- a/typescript/infra/src/agents/index.ts
+++ b/typescript/infra/src/agents/index.ts
@@ -166,8 +166,29 @@ export async function getAgentEnvVars(
 
     if (role === KEY_ROLE_ENUM.Relayer) {
       envVars.push(
-        `OPT_RELAYER_INTERVAL=${valueDict.abacus.relayer.pollingInterval}`,
+        `OPT_RELAYER_POLLINGINTERVAL=${valueDict.abacus.relayer.pollingInterval}`,
       );
+
+      // TODO change
+      envVars.push(
+        `OPT_RELAYER_SUBMISSIONLATENCY=${valueDict.abacus.relayer.pollingInterval}`,
+      );
+
+      // TODO change
+      envVars.push(
+        `OPT_RELAYER_MAXRETRIES=${valueDict.abacus.relayer.pollingInterval}`,
+      );
+
+          /// The polling interval to check for new checkpoints in seconds
+    // pollinginterval: String,
+    // /// The minimum latency in seconds between two relayed checkpoints on the inbox
+    // submissionlatency: String,
+    // /// The maxinmum number of times a processor will try to process a message
+    // maxretries: String,
+    // /// Whether the CheckpointRelayer should try to immediately process messages
+    // relayermessageprocessing: String,
+    // /// The multisig checkpoint syncer configuration
+    // multisigcheckpointsyncer: abacus_base::MultisigCheckpointSyncerConf,
     }
   } catch (error) {
     // This happens if you don't have a result type

--- a/typescript/infra/src/config/agent.ts
+++ b/typescript/infra/src/config/agent.ts
@@ -75,9 +75,9 @@ export type RustContractBlock = {
 export type RustConfig = {
   environment: DeployEnvironment;
   signers: Partial<Record<ChainName, RustSigner>>;
-  // Agents have not yet been moved to use the Outbox/Inbox names.
-  replicas: Partial<Record<ChainName, RustContractBlock>>;
-  home: RustContractBlock;
+  outbox: RustContractBlock;
+  inboxes: Partial<Record<ChainName, RustContractBlock>>;
+  inboxValidatorManagers: Partial<Record<ChainName, RustContractBlock>>;
   tracing: {
     level: string;
     fmt: 'json';

--- a/typescript/infra/src/config/agent.ts
+++ b/typescript/infra/src/config/agent.ts
@@ -74,12 +74,12 @@ export type RustContractBlock<T> = {
 
 export type OutboxAddresses = {
   outbox: types.Address;
-}
+};
 
 export type InboxAddresses = {
   inbox: types.Address;
   validatorManager: types.Address;
-}
+};
 
 export type RustConfig = {
   environment: DeployEnvironment;

--- a/typescript/infra/src/config/agent.ts
+++ b/typescript/infra/src/config/agent.ts
@@ -64,20 +64,28 @@ export type RustConnection = {
   url: string;
 };
 
-export type RustContractBlock = {
-  address: types.Address;
+export type RustContractBlock<T> = {
+  addresses: T;
   domain: string;
   name: ChainName;
   rpcStyle: string; // TODO
   connection: RustConnection;
 };
 
+export type OutboxAddresses = {
+  outbox: types.Address;
+}
+
+export type InboxAddresses = {
+  inbox: types.Address;
+  validatorManager: types.Address;
+}
+
 export type RustConfig = {
   environment: DeployEnvironment;
   signers: Partial<Record<ChainName, RustSigner>>;
-  outbox: RustContractBlock;
-  inboxes: Partial<Record<ChainName, RustContractBlock>>;
-  inboxValidatorManagers: Partial<Record<ChainName, RustContractBlock>>;
+  outbox: RustContractBlock<OutboxAddresses>;
+  inboxes: Partial<Record<ChainName, RustContractBlock<InboxAddresses>>>;
   tracing: {
     level: string;
     fmt: 'json';

--- a/typescript/infra/src/core/deploy.ts
+++ b/typescript/infra/src/core/deploy.ts
@@ -178,8 +178,9 @@ export class AbacusCoreDeployer extends AbacusAppDeployer<
       const rustConfig: RustConfig = {
         environment,
         signers: {},
-        replicas: {},
-        home: outbox,
+        outbox,
+        inboxes: {},
+        inboxValidatorManagers: {},
         tracing: {
           level: 'debug',
           fmt: 'json',
@@ -193,8 +194,8 @@ export class AbacusCoreDeployer extends AbacusAppDeployer<
         const inboxAddress = remoteAddresses.inboxes[name];
         if (!inboxAddress)
           throw new Error(`No inbox for ${domain} on ${remote}`);
-        const inbox = {
-          address: inboxAddress.proxy,
+
+        const common = {
           domain: remote.toString(),
           name: remoteName,
           rpcStyle: 'ethereum',
@@ -203,9 +204,27 @@ export class AbacusCoreDeployer extends AbacusAppDeployer<
             url: '',
           },
         };
+        const inbox = {
+          ...common,
+          address: inboxAddress.proxy,
+        };
 
-        rustConfig.replicas[remoteName] = inbox;
+        const inboxValidatorManagerAddress =
+          remoteAddresses.inboxValidatorManagers[name];
+        if (!inboxValidatorManagerAddress)
+          throw new Error(
+            `No inbox validator manager for ${domain} on ${remote}`,
+          );
+
+        const inboxValidatorManager = {
+          ...common,
+          address: inboxValidatorManagerAddress,
+        };
+
+        rustConfig.inboxes[remoteName] = inbox;
+        rustConfig.inboxValidatorManagers[remoteName] = inboxValidatorManager;
       }
+      console.log('hello', filepath, rustConfig)
       AbacusAppDeployer.writeJson(filepath, rustConfig);
     }
   }

--- a/typescript/infra/src/core/deploy.ts
+++ b/typescript/infra/src/core/deploy.ts
@@ -197,7 +197,7 @@ export class AbacusCoreDeployer extends AbacusAppDeployer<
           throw new Error(`No inbox for ${domain} on ${remote}`);
 
         const inboxValidatorManagerAddress =
-        remoteAddresses.inboxValidatorManagers[name];
+          remoteAddresses.inboxValidatorManagers[name];
         if (!inboxValidatorManagerAddress) {
           throw new Error(
             `No inbox validator manager for ${domain} on ${remote}`,
@@ -215,7 +215,7 @@ export class AbacusCoreDeployer extends AbacusAppDeployer<
           addresses: {
             inbox: inboxAddress.proxy,
             validatorManager: inboxValidatorManagerAddress,
-          }
+          },
         };
 
         rustConfig.inboxes[remoteName] = inbox;

--- a/typescript/infra/src/core/deploy.ts
+++ b/typescript/infra/src/core/deploy.ts
@@ -165,7 +165,9 @@ export class AbacusCoreDeployer extends AbacusAppDeployer<
       const addresses = this.mustGetAddresses(domain);
 
       const outbox = {
-        address: addresses.outbox.proxy,
+        addresses: {
+          outbox: addresses.outbox.proxy,
+        },
         domain: domain.toString(),
         name,
         rpcStyle: 'ethereum',
@@ -180,7 +182,6 @@ export class AbacusCoreDeployer extends AbacusAppDeployer<
         signers: {},
         outbox,
         inboxes: {},
-        inboxValidatorManagers: {},
         tracing: {
           level: 'debug',
           fmt: 'json',
@@ -195,7 +196,15 @@ export class AbacusCoreDeployer extends AbacusAppDeployer<
         if (!inboxAddress)
           throw new Error(`No inbox for ${domain} on ${remote}`);
 
-        const common = {
+        const inboxValidatorManagerAddress =
+        remoteAddresses.inboxValidatorManagers[name];
+        if (!inboxValidatorManagerAddress) {
+          throw new Error(
+            `No inbox validator manager for ${domain} on ${remote}`,
+          );
+        }
+
+        const inbox = {
           domain: remote.toString(),
           name: remoteName,
           rpcStyle: 'ethereum',
@@ -203,28 +212,14 @@ export class AbacusCoreDeployer extends AbacusAppDeployer<
             type: 'http',
             url: '',
           },
-        };
-        const inbox = {
-          ...common,
-          address: inboxAddress.proxy,
-        };
-
-        const inboxValidatorManagerAddress =
-          remoteAddresses.inboxValidatorManagers[name];
-        if (!inboxValidatorManagerAddress)
-          throw new Error(
-            `No inbox validator manager for ${domain} on ${remote}`,
-          );
-
-        const inboxValidatorManager = {
-          ...common,
-          address: inboxValidatorManagerAddress,
+          addresses: {
+            inbox: inboxAddress.proxy,
+            validatorManager: inboxValidatorManagerAddress,
+          }
         };
 
         rustConfig.inboxes[remoteName] = inbox;
-        rustConfig.inboxValidatorManagers[remoteName] = inboxValidatorManager;
       }
-      console.log('hello', filepath, rustConfig)
       AbacusAppDeployer.writeJson(filepath, rustConfig);
     }
   }

--- a/typescript/sdk/src/core/environments/test.ts
+++ b/typescript/sdk/src/core/environments/test.ts
@@ -1,134 +1,134 @@
 export const addresses = {
-  "alfajores": {
-    "upgradeBeaconController": "0x5FbDB2315678afecb367f032d93F642f64180aa3",
-    "xAppConnectionManager": "0x0165878A594ca255338adfa4d48449f69242Eb8F",
-    "interchainGasPaymaster": "0x5FC8d32690cc91D4c39d9d3abcBD16989F875707",
-    "outboxValidatorManager": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
-    "inboxValidatorManagers": {
-      "kovan": "0x8A791620dd6260079BF849Dc5567aDC3F2FdC318",
-      "mumbai": "0x9A676e781A523b5d0C0e43731313A708CB607508",
-      "fuji": "0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE"
+  alfajores: {
+    upgradeBeaconController: '0x5FbDB2315678afecb367f032d93F642f64180aa3',
+    xAppConnectionManager: '0x0165878A594ca255338adfa4d48449f69242Eb8F',
+    interchainGasPaymaster: '0x5FC8d32690cc91D4c39d9d3abcBD16989F875707',
+    outboxValidatorManager: '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512',
+    inboxValidatorManagers: {
+      kovan: '0x8A791620dd6260079BF849Dc5567aDC3F2FdC318',
+      mumbai: '0x9A676e781A523b5d0C0e43731313A708CB607508',
+      fuji: '0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE',
     },
-    "outbox": {
-      "proxy": "0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9",
-      "implementation": "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0",
-      "beacon": "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9"
+    outbox: {
+      proxy: '0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9',
+      implementation: '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0',
+      beacon: '0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9',
     },
-    "inboxes": {
-      "kovan": {
-        "proxy": "0xA51c1fc2f0D1a1b8494Ed1FE312d7C3a78Ed91C0",
-        "implementation": "0x610178dA211FEF7D417bC0e6FeD39F05609AD788",
-        "beacon": "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e"
+    inboxes: {
+      kovan: {
+        proxy: '0xA51c1fc2f0D1a1b8494Ed1FE312d7C3a78Ed91C0',
+        implementation: '0x610178dA211FEF7D417bC0e6FeD39F05609AD788',
+        beacon: '0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e',
       },
-      "mumbai": {
-        "proxy": "0x0B306BF915C4d645ff596e518fAf3F9669b97016",
-        "implementation": "0x610178dA211FEF7D417bC0e6FeD39F05609AD788",
-        "beacon": "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e"
+      mumbai: {
+        proxy: '0x0B306BF915C4d645ff596e518fAf3F9669b97016',
+        implementation: '0x610178dA211FEF7D417bC0e6FeD39F05609AD788',
+        beacon: '0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e',
       },
-      "fuji": {
-        "proxy": "0x68B1D87F95878fE05B998F19b66F4baba5De1aed",
-        "implementation": "0x610178dA211FEF7D417bC0e6FeD39F05609AD788",
-        "beacon": "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e"
-      }
-    }
+      fuji: {
+        proxy: '0x68B1D87F95878fE05B998F19b66F4baba5De1aed',
+        implementation: '0x610178dA211FEF7D417bC0e6FeD39F05609AD788',
+        beacon: '0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e',
+      },
+    },
   },
-  "kovan": {
-    "upgradeBeaconController": "0xc6e7DF5E7b4f2A278906862b61205850344D4e7d",
-    "xAppConnectionManager": "0x7a2088a1bFc9d81c55368AE168C2C02570cB814F",
-    "interchainGasPaymaster": "0x4A679253410272dd5232B3Ff7cF5dbB88f295319",
-    "outboxValidatorManager": "0x59b670e9fA9D0A427751Af201D676719a970857b",
-    "inboxValidatorManagers": {
-      "alfajores": "0x67d269191c92Caf3cD7723F116c85e6E9bf55933",
-      "mumbai": "0xa82fF9aFd8f496c3d6ac40E2a0F282E47488CFc9",
-      "fuji": "0xf5059a5D33d5853360D16C683c16e67980206f36"
+  kovan: {
+    upgradeBeaconController: '0xc6e7DF5E7b4f2A278906862b61205850344D4e7d',
+    xAppConnectionManager: '0x7a2088a1bFc9d81c55368AE168C2C02570cB814F',
+    interchainGasPaymaster: '0x4A679253410272dd5232B3Ff7cF5dbB88f295319',
+    outboxValidatorManager: '0x59b670e9fA9D0A427751Af201D676719a970857b',
+    inboxValidatorManagers: {
+      alfajores: '0x67d269191c92Caf3cD7723F116c85e6E9bf55933',
+      mumbai: '0xa82fF9aFd8f496c3d6ac40E2a0F282E47488CFc9',
+      fuji: '0xf5059a5D33d5853360D16C683c16e67980206f36',
     },
-    "outbox": {
-      "proxy": "0xa85233C63b9Ee964Add6F2cffe00Fd84eb32338f",
-      "implementation": "0x4ed7c70F96B99c776995fB64377f0d4aB3B0e1C1",
-      "beacon": "0x322813Fd9A801c5507c9de605d63CEA4f2CE6c44"
+    outbox: {
+      proxy: '0xa85233C63b9Ee964Add6F2cffe00Fd84eb32338f',
+      implementation: '0x4ed7c70F96B99c776995fB64377f0d4aB3B0e1C1',
+      beacon: '0x322813Fd9A801c5507c9de605d63CEA4f2CE6c44',
     },
-    "inboxes": {
-      "alfajores": {
-        "proxy": "0x84eA74d481Ee0A5332c457a4d796187F6Ba67fEB",
-        "implementation": "0xE6E340D132b5f46d1e472DebcD681B2aBc16e57E",
-        "beacon": "0xc3e53F4d16Ae77Db1c982e75a937B9f60FE63690"
+    inboxes: {
+      alfajores: {
+        proxy: '0x84eA74d481Ee0A5332c457a4d796187F6Ba67fEB',
+        implementation: '0xE6E340D132b5f46d1e472DebcD681B2aBc16e57E',
+        beacon: '0xc3e53F4d16Ae77Db1c982e75a937B9f60FE63690',
       },
-      "mumbai": {
-        "proxy": "0x1613beB3B2C4f22Ee086B2b38C1476A3cE7f78E8",
-        "implementation": "0xE6E340D132b5f46d1e472DebcD681B2aBc16e57E",
-        "beacon": "0xc3e53F4d16Ae77Db1c982e75a937B9f60FE63690"
+      mumbai: {
+        proxy: '0x1613beB3B2C4f22Ee086B2b38C1476A3cE7f78E8',
+        implementation: '0xE6E340D132b5f46d1e472DebcD681B2aBc16e57E',
+        beacon: '0xc3e53F4d16Ae77Db1c982e75a937B9f60FE63690',
       },
-      "fuji": {
-        "proxy": "0x95401dc811bb5740090279Ba06cfA8fcF6113778",
-        "implementation": "0xE6E340D132b5f46d1e472DebcD681B2aBc16e57E",
-        "beacon": "0xc3e53F4d16Ae77Db1c982e75a937B9f60FE63690"
-      }
-    }
+      fuji: {
+        proxy: '0x95401dc811bb5740090279Ba06cfA8fcF6113778',
+        implementation: '0xE6E340D132b5f46d1e472DebcD681B2aBc16e57E',
+        beacon: '0xc3e53F4d16Ae77Db1c982e75a937B9f60FE63690',
+      },
+    },
   },
-  "mumbai": {
-    "upgradeBeaconController": "0x70e0bA845a1A0F2DA3359C97E0285013525FFC49",
-    "xAppConnectionManager": "0x5eb3Bc0a489C5A8288765d2336659EbCA68FCd00",
-    "interchainGasPaymaster": "0x9d4454B023096f34B160D6B654540c56A1F81688",
-    "outboxValidatorManager": "0x4826533B4897376654Bb4d4AD88B7faFD0C98528",
-    "inboxValidatorManagers": {
-      "alfajores": "0x4c5859f0F772848b2D91F1D83E2Fe57935348029",
-      "kovan": "0x82e01223d51Eb87e16A03E24687EDF0F294da6f1",
-      "fuji": "0x7bc06c482DEAd17c0e297aFbC32f6e63d3846650"
+  mumbai: {
+    upgradeBeaconController: '0x70e0bA845a1A0F2DA3359C97E0285013525FFC49',
+    xAppConnectionManager: '0x5eb3Bc0a489C5A8288765d2336659EbCA68FCd00',
+    interchainGasPaymaster: '0x9d4454B023096f34B160D6B654540c56A1F81688',
+    outboxValidatorManager: '0x4826533B4897376654Bb4d4AD88B7faFD0C98528',
+    inboxValidatorManagers: {
+      alfajores: '0x4c5859f0F772848b2D91F1D83E2Fe57935348029',
+      kovan: '0x82e01223d51Eb87e16A03E24687EDF0F294da6f1',
+      fuji: '0x7bc06c482DEAd17c0e297aFbC32f6e63d3846650',
     },
-    "outbox": {
-      "proxy": "0x8f86403A4DE0BB5791fa46B8e795C547942fE4Cf",
-      "implementation": "0x99bbA657f2BbC93c02D617f8bA121cB8Fc104Acf",
-      "beacon": "0x0E801D84Fa97b50751Dbf25036d067dCf18858bF"
+    outbox: {
+      proxy: '0x8f86403A4DE0BB5791fa46B8e795C547942fE4Cf',
+      implementation: '0x99bbA657f2BbC93c02D617f8bA121cB8Fc104Acf',
+      beacon: '0x0E801D84Fa97b50751Dbf25036d067dCf18858bF',
     },
-    "inboxes": {
-      "alfajores": {
-        "proxy": "0xb7278A61aa25c888815aFC32Ad3cC52fF24fE575",
-        "implementation": "0x1291Be112d480055DaFd8a610b7d1e203891C274",
-        "beacon": "0x5f3f1dBD7B74C6B46e8c44f98792A1dAf8d69154"
+    inboxes: {
+      alfajores: {
+        proxy: '0xb7278A61aa25c888815aFC32Ad3cC52fF24fE575',
+        implementation: '0x1291Be112d480055DaFd8a610b7d1e203891C274',
+        beacon: '0x5f3f1dBD7B74C6B46e8c44f98792A1dAf8d69154',
       },
-      "kovan": {
-        "proxy": "0x2bdCC0de6bE1f7D2ee689a0342D76F52E8EFABa3",
-        "implementation": "0x1291Be112d480055DaFd8a610b7d1e203891C274",
-        "beacon": "0x5f3f1dBD7B74C6B46e8c44f98792A1dAf8d69154"
+      kovan: {
+        proxy: '0x2bdCC0de6bE1f7D2ee689a0342D76F52E8EFABa3',
+        implementation: '0x1291Be112d480055DaFd8a610b7d1e203891C274',
+        beacon: '0x5f3f1dBD7B74C6B46e8c44f98792A1dAf8d69154',
       },
-      "fuji": {
-        "proxy": "0xc351628EB244ec633d5f21fBD6621e1a683B1181",
-        "implementation": "0x1291Be112d480055DaFd8a610b7d1e203891C274",
-        "beacon": "0x5f3f1dBD7B74C6B46e8c44f98792A1dAf8d69154"
-      }
-    }
+      fuji: {
+        proxy: '0xc351628EB244ec633d5f21fBD6621e1a683B1181',
+        implementation: '0x1291Be112d480055DaFd8a610b7d1e203891C274',
+        beacon: '0x5f3f1dBD7B74C6B46e8c44f98792A1dAf8d69154',
+      },
+    },
   },
-  "fuji": {
-    "upgradeBeaconController": "0xcbEAF3BDe82155F56486Fb5a1072cb8baAf547cc",
-    "xAppConnectionManager": "0x1fA02b2d6A771842690194Cf62D91bdd92BfE28d",
-    "interchainGasPaymaster": "0x5081a39b8A5f0E35a8D959395a630b68B74Dd30f",
-    "outboxValidatorManager": "0x1429859428C0aBc9C2C47C8Ee9FBaf82cFA0F20f",
-    "inboxValidatorManagers": {
-      "alfajores": "0x4C4a2f8c81640e47606d3fd77B353E87Ba015584",
-      "kovan": "0x51A1ceB83B83F1985a81C295d1fF28Afef186E02",
-      "mumbai": "0x0355B7B8cb128fA5692729Ab3AAa199C1753f726"
+  fuji: {
+    upgradeBeaconController: '0xcbEAF3BDe82155F56486Fb5a1072cb8baAf547cc',
+    xAppConnectionManager: '0x1fA02b2d6A771842690194Cf62D91bdd92BfE28d',
+    interchainGasPaymaster: '0x5081a39b8A5f0E35a8D959395a630b68B74Dd30f',
+    outboxValidatorManager: '0x1429859428C0aBc9C2C47C8Ee9FBaf82cFA0F20f',
+    inboxValidatorManagers: {
+      alfajores: '0x4C4a2f8c81640e47606d3fd77B353E87Ba015584',
+      kovan: '0x51A1ceB83B83F1985a81C295d1fF28Afef186E02',
+      mumbai: '0x0355B7B8cb128fA5692729Ab3AAa199C1753f726',
     },
-    "outbox": {
-      "proxy": "0x922D6956C99E12DFeB3224DEA977D0939758A1Fe",
-      "implementation": "0xB0D4afd8879eD9F52b28595d31B441D079B2Ca07",
-      "beacon": "0x162A433068F51e18b7d13932F27e66a3f99E6890"
+    outbox: {
+      proxy: '0x922D6956C99E12DFeB3224DEA977D0939758A1Fe',
+      implementation: '0xB0D4afd8879eD9F52b28595d31B441D079B2Ca07',
+      beacon: '0x162A433068F51e18b7d13932F27e66a3f99E6890',
     },
-    "inboxes": {
-      "alfajores": {
-        "proxy": "0xD8a5a9b31c3C0232E196d518E89Fd8bF83AcAd43",
-        "implementation": "0x21dF544947ba3E8b3c32561399E88B52Dc8b2823",
-        "beacon": "0x2E2Ed0Cfd3AD2f1d34481277b3204d807Ca2F8c2"
+    inboxes: {
+      alfajores: {
+        proxy: '0xD8a5a9b31c3C0232E196d518E89Fd8bF83AcAd43',
+        implementation: '0x21dF544947ba3E8b3c32561399E88B52Dc8b2823',
+        beacon: '0x2E2Ed0Cfd3AD2f1d34481277b3204d807Ca2F8c2',
       },
-      "kovan": {
-        "proxy": "0x36b58F5C1969B7b6591D752ea6F5486D069010AB",
-        "implementation": "0x21dF544947ba3E8b3c32561399E88B52Dc8b2823",
-        "beacon": "0x2E2Ed0Cfd3AD2f1d34481277b3204d807Ca2F8c2"
+      kovan: {
+        proxy: '0x36b58F5C1969B7b6591D752ea6F5486D069010AB',
+        implementation: '0x21dF544947ba3E8b3c32561399E88B52Dc8b2823',
+        beacon: '0x2E2Ed0Cfd3AD2f1d34481277b3204d807Ca2F8c2',
       },
-      "mumbai": {
-        "proxy": "0x202CCe504e04bEd6fC0521238dDf04Bc9E8E15aB",
-        "implementation": "0x21dF544947ba3E8b3c32561399E88B52Dc8b2823",
-        "beacon": "0x2E2Ed0Cfd3AD2f1d34481277b3204d807Ca2F8c2"
-      }
-    }
-  }
-}
+      mumbai: {
+        proxy: '0x202CCe504e04bEd6fC0521238dDf04Bc9E8E15aB',
+        implementation: '0x21dF544947ba3E8b3c32561399E88B52Dc8b2823',
+        beacon: '0x2E2Ed0Cfd3AD2f1d34481277b3204d807Ca2F8c2',
+      },
+    },
+  },
+};

--- a/typescript/sdk/src/core/environments/test.ts
+++ b/typescript/sdk/src/core/environments/test.ts
@@ -1,134 +1,134 @@
 export const addresses = {
-  alfajores: {
-    upgradeBeaconController: '0x5FbDB2315678afecb367f032d93F642f64180aa3',
-    xAppConnectionManager: '0x0165878A594ca255338adfa4d48449f69242Eb8F',
-    interchainGasPaymaster: '0x5FC8d32690cc91D4c39d9d3abcBD16989F875707',
-    outboxValidatorManager: '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512',
-    inboxValidatorManagers: {
-      kovan: '0x8A791620dd6260079BF849Dc5567aDC3F2FdC318',
-      mumbai: '0x9A676e781A523b5d0C0e43731313A708CB607508',
-      fuji: '0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE',
+  "alfajores": {
+    "upgradeBeaconController": "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+    "xAppConnectionManager": "0x0165878A594ca255338adfa4d48449f69242Eb8F",
+    "interchainGasPaymaster": "0x5FC8d32690cc91D4c39d9d3abcBD16989F875707",
+    "outboxValidatorManager": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
+    "inboxValidatorManagers": {
+      "kovan": "0x8A791620dd6260079BF849Dc5567aDC3F2FdC318",
+      "mumbai": "0x9A676e781A523b5d0C0e43731313A708CB607508",
+      "fuji": "0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE"
     },
-    outbox: {
-      proxy: '0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9',
-      implementation: '0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0',
-      beacon: '0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9',
+    "outbox": {
+      "proxy": "0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9",
+      "implementation": "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0",
+      "beacon": "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9"
     },
-    inboxes: {
-      kovan: {
-        proxy: '0xA51c1fc2f0D1a1b8494Ed1FE312d7C3a78Ed91C0',
-        implementation: '0x610178dA211FEF7D417bC0e6FeD39F05609AD788',
-        beacon: '0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e',
+    "inboxes": {
+      "kovan": {
+        "proxy": "0xA51c1fc2f0D1a1b8494Ed1FE312d7C3a78Ed91C0",
+        "implementation": "0x610178dA211FEF7D417bC0e6FeD39F05609AD788",
+        "beacon": "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e"
       },
-      mumbai: {
-        proxy: '0x0B306BF915C4d645ff596e518fAf3F9669b97016',
-        implementation: '0x610178dA211FEF7D417bC0e6FeD39F05609AD788',
-        beacon: '0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e',
+      "mumbai": {
+        "proxy": "0x0B306BF915C4d645ff596e518fAf3F9669b97016",
+        "implementation": "0x610178dA211FEF7D417bC0e6FeD39F05609AD788",
+        "beacon": "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e"
       },
-      fuji: {
-        proxy: '0x68B1D87F95878fE05B998F19b66F4baba5De1aed',
-        implementation: '0x610178dA211FEF7D417bC0e6FeD39F05609AD788',
-        beacon: '0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e',
-      },
-    },
+      "fuji": {
+        "proxy": "0x68B1D87F95878fE05B998F19b66F4baba5De1aed",
+        "implementation": "0x610178dA211FEF7D417bC0e6FeD39F05609AD788",
+        "beacon": "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e"
+      }
+    }
   },
-  kovan: {
-    upgradeBeaconController: '0xc6e7DF5E7b4f2A278906862b61205850344D4e7d',
-    xAppConnectionManager: '0x7a2088a1bFc9d81c55368AE168C2C02570cB814F',
-    interchainGasPaymaster: '0x4A679253410272dd5232B3Ff7cF5dbB88f295319',
-    outboxValidatorManager: '0x59b670e9fA9D0A427751Af201D676719a970857b',
-    inboxValidatorManagers: {
-      alfajores: '0x67d269191c92Caf3cD7723F116c85e6E9bf55933',
-      mumbai: '0xa82fF9aFd8f496c3d6ac40E2a0F282E47488CFc9',
-      fuji: '0xf5059a5D33d5853360D16C683c16e67980206f36',
+  "kovan": {
+    "upgradeBeaconController": "0xc6e7DF5E7b4f2A278906862b61205850344D4e7d",
+    "xAppConnectionManager": "0x7a2088a1bFc9d81c55368AE168C2C02570cB814F",
+    "interchainGasPaymaster": "0x4A679253410272dd5232B3Ff7cF5dbB88f295319",
+    "outboxValidatorManager": "0x59b670e9fA9D0A427751Af201D676719a970857b",
+    "inboxValidatorManagers": {
+      "alfajores": "0x67d269191c92Caf3cD7723F116c85e6E9bf55933",
+      "mumbai": "0xa82fF9aFd8f496c3d6ac40E2a0F282E47488CFc9",
+      "fuji": "0xf5059a5D33d5853360D16C683c16e67980206f36"
     },
-    outbox: {
-      proxy: '0xa85233C63b9Ee964Add6F2cffe00Fd84eb32338f',
-      implementation: '0x4ed7c70F96B99c776995fB64377f0d4aB3B0e1C1',
-      beacon: '0x322813Fd9A801c5507c9de605d63CEA4f2CE6c44',
+    "outbox": {
+      "proxy": "0xa85233C63b9Ee964Add6F2cffe00Fd84eb32338f",
+      "implementation": "0x4ed7c70F96B99c776995fB64377f0d4aB3B0e1C1",
+      "beacon": "0x322813Fd9A801c5507c9de605d63CEA4f2CE6c44"
     },
-    inboxes: {
-      alfajores: {
-        proxy: '0x84eA74d481Ee0A5332c457a4d796187F6Ba67fEB',
-        implementation: '0xE6E340D132b5f46d1e472DebcD681B2aBc16e57E',
-        beacon: '0xc3e53F4d16Ae77Db1c982e75a937B9f60FE63690',
+    "inboxes": {
+      "alfajores": {
+        "proxy": "0x84eA74d481Ee0A5332c457a4d796187F6Ba67fEB",
+        "implementation": "0xE6E340D132b5f46d1e472DebcD681B2aBc16e57E",
+        "beacon": "0xc3e53F4d16Ae77Db1c982e75a937B9f60FE63690"
       },
-      mumbai: {
-        proxy: '0x1613beB3B2C4f22Ee086B2b38C1476A3cE7f78E8',
-        implementation: '0xE6E340D132b5f46d1e472DebcD681B2aBc16e57E',
-        beacon: '0xc3e53F4d16Ae77Db1c982e75a937B9f60FE63690',
+      "mumbai": {
+        "proxy": "0x1613beB3B2C4f22Ee086B2b38C1476A3cE7f78E8",
+        "implementation": "0xE6E340D132b5f46d1e472DebcD681B2aBc16e57E",
+        "beacon": "0xc3e53F4d16Ae77Db1c982e75a937B9f60FE63690"
       },
-      fuji: {
-        proxy: '0x95401dc811bb5740090279Ba06cfA8fcF6113778',
-        implementation: '0xE6E340D132b5f46d1e472DebcD681B2aBc16e57E',
-        beacon: '0xc3e53F4d16Ae77Db1c982e75a937B9f60FE63690',
-      },
-    },
+      "fuji": {
+        "proxy": "0x95401dc811bb5740090279Ba06cfA8fcF6113778",
+        "implementation": "0xE6E340D132b5f46d1e472DebcD681B2aBc16e57E",
+        "beacon": "0xc3e53F4d16Ae77Db1c982e75a937B9f60FE63690"
+      }
+    }
   },
-  mumbai: {
-    upgradeBeaconController: '0x70e0bA845a1A0F2DA3359C97E0285013525FFC49',
-    xAppConnectionManager: '0x5eb3Bc0a489C5A8288765d2336659EbCA68FCd00',
-    interchainGasPaymaster: '0x9d4454B023096f34B160D6B654540c56A1F81688',
-    outboxValidatorManager: '0x4826533B4897376654Bb4d4AD88B7faFD0C98528',
-    inboxValidatorManagers: {
-      alfajores: '0x4c5859f0F772848b2D91F1D83E2Fe57935348029',
-      kovan: '0x82e01223d51Eb87e16A03E24687EDF0F294da6f1',
-      fuji: '0x7bc06c482DEAd17c0e297aFbC32f6e63d3846650',
+  "mumbai": {
+    "upgradeBeaconController": "0x70e0bA845a1A0F2DA3359C97E0285013525FFC49",
+    "xAppConnectionManager": "0x5eb3Bc0a489C5A8288765d2336659EbCA68FCd00",
+    "interchainGasPaymaster": "0x9d4454B023096f34B160D6B654540c56A1F81688",
+    "outboxValidatorManager": "0x4826533B4897376654Bb4d4AD88B7faFD0C98528",
+    "inboxValidatorManagers": {
+      "alfajores": "0x4c5859f0F772848b2D91F1D83E2Fe57935348029",
+      "kovan": "0x82e01223d51Eb87e16A03E24687EDF0F294da6f1",
+      "fuji": "0x7bc06c482DEAd17c0e297aFbC32f6e63d3846650"
     },
-    outbox: {
-      proxy: '0x8f86403A4DE0BB5791fa46B8e795C547942fE4Cf',
-      implementation: '0x99bbA657f2BbC93c02D617f8bA121cB8Fc104Acf',
-      beacon: '0x0E801D84Fa97b50751Dbf25036d067dCf18858bF',
+    "outbox": {
+      "proxy": "0x8f86403A4DE0BB5791fa46B8e795C547942fE4Cf",
+      "implementation": "0x99bbA657f2BbC93c02D617f8bA121cB8Fc104Acf",
+      "beacon": "0x0E801D84Fa97b50751Dbf25036d067dCf18858bF"
     },
-    inboxes: {
-      alfajores: {
-        proxy: '0xb7278A61aa25c888815aFC32Ad3cC52fF24fE575',
-        implementation: '0x1291Be112d480055DaFd8a610b7d1e203891C274',
-        beacon: '0x5f3f1dBD7B74C6B46e8c44f98792A1dAf8d69154',
+    "inboxes": {
+      "alfajores": {
+        "proxy": "0xb7278A61aa25c888815aFC32Ad3cC52fF24fE575",
+        "implementation": "0x1291Be112d480055DaFd8a610b7d1e203891C274",
+        "beacon": "0x5f3f1dBD7B74C6B46e8c44f98792A1dAf8d69154"
       },
-      kovan: {
-        proxy: '0x2bdCC0de6bE1f7D2ee689a0342D76F52E8EFABa3',
-        implementation: '0x1291Be112d480055DaFd8a610b7d1e203891C274',
-        beacon: '0x5f3f1dBD7B74C6B46e8c44f98792A1dAf8d69154',
+      "kovan": {
+        "proxy": "0x2bdCC0de6bE1f7D2ee689a0342D76F52E8EFABa3",
+        "implementation": "0x1291Be112d480055DaFd8a610b7d1e203891C274",
+        "beacon": "0x5f3f1dBD7B74C6B46e8c44f98792A1dAf8d69154"
       },
-      fuji: {
-        proxy: '0xc351628EB244ec633d5f21fBD6621e1a683B1181',
-        implementation: '0x1291Be112d480055DaFd8a610b7d1e203891C274',
-        beacon: '0x5f3f1dBD7B74C6B46e8c44f98792A1dAf8d69154',
-      },
-    },
+      "fuji": {
+        "proxy": "0xc351628EB244ec633d5f21fBD6621e1a683B1181",
+        "implementation": "0x1291Be112d480055DaFd8a610b7d1e203891C274",
+        "beacon": "0x5f3f1dBD7B74C6B46e8c44f98792A1dAf8d69154"
+      }
+    }
   },
-  fuji: {
-    upgradeBeaconController: '0xcbEAF3BDe82155F56486Fb5a1072cb8baAf547cc',
-    xAppConnectionManager: '0x1fA02b2d6A771842690194Cf62D91bdd92BfE28d',
-    interchainGasPaymaster: '0x5081a39b8A5f0E35a8D959395a630b68B74Dd30f',
-    outboxValidatorManager: '0x1429859428C0aBc9C2C47C8Ee9FBaf82cFA0F20f',
-    inboxValidatorManagers: {
-      alfajores: '0x4C4a2f8c81640e47606d3fd77B353E87Ba015584',
-      kovan: '0x51A1ceB83B83F1985a81C295d1fF28Afef186E02',
-      mumbai: '0x0355B7B8cb128fA5692729Ab3AAa199C1753f726',
+  "fuji": {
+    "upgradeBeaconController": "0xcbEAF3BDe82155F56486Fb5a1072cb8baAf547cc",
+    "xAppConnectionManager": "0x1fA02b2d6A771842690194Cf62D91bdd92BfE28d",
+    "interchainGasPaymaster": "0x5081a39b8A5f0E35a8D959395a630b68B74Dd30f",
+    "outboxValidatorManager": "0x1429859428C0aBc9C2C47C8Ee9FBaf82cFA0F20f",
+    "inboxValidatorManagers": {
+      "alfajores": "0x4C4a2f8c81640e47606d3fd77B353E87Ba015584",
+      "kovan": "0x51A1ceB83B83F1985a81C295d1fF28Afef186E02",
+      "mumbai": "0x0355B7B8cb128fA5692729Ab3AAa199C1753f726"
     },
-    outbox: {
-      proxy: '0x922D6956C99E12DFeB3224DEA977D0939758A1Fe',
-      implementation: '0xB0D4afd8879eD9F52b28595d31B441D079B2Ca07',
-      beacon: '0x162A433068F51e18b7d13932F27e66a3f99E6890',
+    "outbox": {
+      "proxy": "0x922D6956C99E12DFeB3224DEA977D0939758A1Fe",
+      "implementation": "0xB0D4afd8879eD9F52b28595d31B441D079B2Ca07",
+      "beacon": "0x162A433068F51e18b7d13932F27e66a3f99E6890"
     },
-    inboxes: {
-      alfajores: {
-        proxy: '0xD8a5a9b31c3C0232E196d518E89Fd8bF83AcAd43',
-        implementation: '0x21dF544947ba3E8b3c32561399E88B52Dc8b2823',
-        beacon: '0x2E2Ed0Cfd3AD2f1d34481277b3204d807Ca2F8c2',
+    "inboxes": {
+      "alfajores": {
+        "proxy": "0xD8a5a9b31c3C0232E196d518E89Fd8bF83AcAd43",
+        "implementation": "0x21dF544947ba3E8b3c32561399E88B52Dc8b2823",
+        "beacon": "0x2E2Ed0Cfd3AD2f1d34481277b3204d807Ca2F8c2"
       },
-      kovan: {
-        proxy: '0x36b58F5C1969B7b6591D752ea6F5486D069010AB',
-        implementation: '0x21dF544947ba3E8b3c32561399E88B52Dc8b2823',
-        beacon: '0x2E2Ed0Cfd3AD2f1d34481277b3204d807Ca2F8c2',
+      "kovan": {
+        "proxy": "0x36b58F5C1969B7b6591D752ea6F5486D069010AB",
+        "implementation": "0x21dF544947ba3E8b3c32561399E88B52Dc8b2823",
+        "beacon": "0x2E2Ed0Cfd3AD2f1d34481277b3204d807Ca2F8c2"
       },
-      mumbai: {
-        proxy: '0x202CCe504e04bEd6fC0521238dDf04Bc9E8E15aB',
-        implementation: '0x21dF544947ba3E8b3c32561399E88B52Dc8b2823',
-        beacon: '0x2E2Ed0Cfd3AD2f1d34481277b3204d807Ca2F8c2',
-      },
-    },
-  },
-};
+      "mumbai": {
+        "proxy": "0x202CCe504e04bEd6fC0521238dDf04Bc9E8E15aB",
+        "implementation": "0x21dF544947ba3E8b3c32561399E88B52Dc8b2823",
+        "beacon": "0x2E2Ed0Cfd3AD2f1d34481277b3204d807Ca2F8c2"
+      }
+    }
+  }
+}


### PR DESCRIPTION
* Adds the InboxValidatorManager to the Rust agents, which is now used for submitting checkpoints on inbox chains instead of calling Inbox.sol directly
* Minor refactor of settings - previously, a `ChainSetup` was used for configuring each contract, which would include a single address, its domain, RPC connection info, etc. Now that we want to configure both Inbox.sol and InboxValidatorManager.sol for each inbox chain, we don't want to have to re-specify common info (like the RPC info / domain / etc). `ChainSetup` now accepts a generic type that can define multiple contract addresses.
* Adds `MultisigCheckpointSyncer`, which reads from multiple CheckpointSyncers. It can figure out the highest index that has a quorum of signatures and can fetch signed checkpoints. The relayer uses this.

Tested:

Ran locally and things worked as expected with the following setup:
* Quorum of 1
* A single validator is operated whose LocalStorage CheckpointSyncer is synced by the relayer's `MultisigCheckpointSyncer`
* Kathy creating messages & checkpoints

I plan to test with a 2/2 quorum but wanted to open the PR prior to testing

This does not include any updates to `output-agent-env-vars.ts`. It's already pretty out of sync with what's on main, so I felt this should just come in a later PR when we want to take the time to get it in sync with the agents