### PR TITLE
Add gauges to track agents

### DIFF
--- a/rust/agents/relayer/src/checkpoint_relayer.rs
+++ b/rust/agents/relayer/src/checkpoint_relayer.rs
@@ -24,6 +24,7 @@ pub(crate) struct CheckpointRelayer {
 }
 
 impl CheckpointRelayer {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         outbox: Outboxes,
         polling_interval: u64,

--- a/rust/agents/relayer/src/message_processor.rs
+++ b/rust/agents/relayer/src/message_processor.rs
@@ -5,9 +5,10 @@ use std::{
     time::{Duration, Instant},
 };
 
-use abacus_base::CachingInbox;
+use abacus_base::{CachingInbox, Outboxes};
 use abacus_core::{db::AbacusDB, AbacusCommon, CommittedMessage, Inbox, MessageStatus};
 use color_eyre::{eyre::bail, Result};
+use prometheus::{IntGauge, IntGaugeVec};
 use tokio::{task::JoinHandle, time::sleep};
 use tracing::{debug, error, info, info_span, instrument::Instrumented, warn, Instrument};
 
@@ -21,6 +22,9 @@ pub(crate) struct MessageProcessor {
     inbox: Arc<CachingInbox>,
     prover_sync: MerkleTreeBuilder,
     retry_queue: BinaryHeap<MessageToRetry>,
+    processor_loop_gauge: IntGauge,
+    processed_gauge: IntGauge,
+    retry_queue_length_gauge: IntGauge,
 }
 
 #[derive(PartialEq, Eq, PartialOrd, Ord)]
@@ -39,12 +43,21 @@ enum MessageProcessingStatus {
 
 impl MessageProcessor {
     pub(crate) fn new(
+        outbox: Outboxes,
         polling_interval: u64,
         max_retries: u32,
         db: AbacusDB,
         reorg_period: u64,
         inbox: Arc<CachingInbox>,
+        leaf_index_gauge: IntGaugeVec,
+        retry_queue_length: IntGaugeVec,
     ) -> Self {
+        let processor_loop_gauge =
+            leaf_index_gauge.with_label_values(&["processor_loop", outbox.name(), inbox.name()]);
+        let processed_gauge =
+            leaf_index_gauge.with_label_values(&["message_processed", outbox.name(), inbox.name()]);
+        let retry_queue_length_gauge =
+            retry_queue_length.with_label_values(&[outbox.name(), inbox.name()]);
         Self {
             polling_interval,
             max_retries,
@@ -53,6 +66,9 @@ impl MessageProcessor {
             db,
             inbox,
             retry_queue: BinaryHeap::new(),
+            processor_loop_gauge,
+            processed_gauge,
+            retry_queue_length_gauge,
         }
     }
 
@@ -136,6 +152,8 @@ impl MessageProcessor {
         let mut message_leaf_index = 0;
         tokio::spawn(async move {
             loop {
+                self.processor_loop_gauge.set(message_leaf_index as i64);
+                self.retry_queue_length_gauge.set(self.retry_queue.len() as i64);
                 if self.db.retrieve_leaf_processing_status(message_leaf_index)?.is_some() {
                     message_leaf_index += 1;
                     continue
@@ -152,7 +170,10 @@ impl MessageProcessor {
                             "Process fresh leaf"
                         );
                         match self.try_processing_message(message_leaf_index).await? {
-                            MessageProcessingStatus::Processed => message_leaf_index += 1,
+                            MessageProcessingStatus::Processed => {
+                                self.processed_gauge.set(message_leaf_index as i64);
+                                message_leaf_index += 1
+                            },
                             MessageProcessingStatus::NotYetCheckpointed => {
                                 // If we don't have an up to date checkpoint, sleep and try again
                                 sleep(Duration::from_secs(self.polling_interval)).await;

--- a/rust/agents/relayer/src/message_processor.rs
+++ b/rust/agents/relayer/src/message_processor.rs
@@ -42,6 +42,7 @@ enum MessageProcessingStatus {
 }
 
 impl MessageProcessor {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         outbox: Outboxes,
         polling_interval: u64,

--- a/rust/agents/relayer/src/relayer.rs
+++ b/rust/agents/relayer/src/relayer.rs
@@ -85,10 +85,8 @@ impl Relayer {
     fn run_contract_sync(&self) -> Instrumented<JoinHandle<Result<()>>> {
         let outbox = self.core.outbox.outbox();
         let outbox_name = outbox.name();
-        let sync_metrics = ContractSyncMetrics::new(
-            self.metrics(),
-            Some(&[&"dispatch", &outbox_name, &"unknown"]),
-        );
+        let sync_metrics =
+            ContractSyncMetrics::new(self.metrics(), Some(&["dispatch", outbox_name, "unknown"]));
         let sync = self.outbox().sync(
             Self::AGENT_NAME.to_string(),
             self.as_ref().indexer.clone(),

--- a/rust/agents/relayer/src/relayer.rs
+++ b/rust/agents/relayer/src/relayer.rs
@@ -1,6 +1,7 @@
+use abacus_core::AbacusCommon;
 use async_trait::async_trait;
 use color_eyre::{eyre::Context, Result};
-use std::sync::Arc;
+
 use tokio::task::JoinHandle;
 use tracing::{instrument::Instrumented, Instrument};
 
@@ -22,7 +23,6 @@ pub struct Relayer {
     relayer_message_processing: bool,
     multisig_checkpoint_syncer: MultisigCheckpointSyncer,
     core: AbacusAgentCore,
-    checkpoints_relayed_count: Arc<prometheus::IntCounterVec>,
 }
 
 impl AsRef<AbacusAgentCore> for Relayer {
@@ -42,16 +42,6 @@ impl Relayer {
         multisig_checkpoint_syncer: MultisigCheckpointSyncer,
         core: AbacusAgentCore,
     ) -> Self {
-        let checkpoints_relayed_count = Arc::new(
-            core.metrics
-                .new_int_counter(
-                    "checkpoints_relayed_count",
-                    "Number of checkpoints relayed from given outbox to inbox",
-                    &["outbox", "inbox", "agent"],
-                )
-                .expect("processor metric already registered -- should be a singleton"),
-        );
-
         Self {
             polling_interval,
             max_retries,
@@ -59,7 +49,6 @@ impl Relayer {
             relayer_message_processing,
             multisig_checkpoint_syncer,
             core,
-            checkpoints_relayed_count,
         }
     }
 }
@@ -94,7 +83,12 @@ impl Agent for Relayer {
 
 impl Relayer {
     fn run_contract_sync(&self) -> Instrumented<JoinHandle<Result<()>>> {
-        let sync_metrics = ContractSyncMetrics::new(self.metrics(), None);
+        let outbox = self.core.outbox.outbox();
+        let outbox_name = outbox.name();
+        let sync_metrics = ContractSyncMetrics::new(
+            self.metrics(),
+            Some(&[&"dispatch", &outbox_name, &"unknown"]),
+        );
         let sync = self.outbox().sync(
             Self::AGENT_NAME.to_string(),
             self.as_ref().indexer.clone(),
@@ -106,19 +100,24 @@ impl Relayer {
     fn run_inbox(&self, inbox_contracts: InboxContracts) -> Instrumented<JoinHandle<Result<()>>> {
         let db = self.outbox().db();
         let checkpoint_relayer = CheckpointRelayer::new(
+            self.outbox().outbox(),
             self.polling_interval,
             self.submission_latency,
             self.relayer_message_processing,
             db.clone(),
             inbox_contracts.clone(),
             self.multisig_checkpoint_syncer.clone(),
+            self.core.metrics.last_known_message_leaf_index(),
         );
         let message_processor = MessageProcessor::new(
+            self.outbox().outbox(),
             self.polling_interval,
             self.max_retries,
             db,
             self.submission_latency,
             inbox_contracts.inbox,
+            self.core.metrics.last_known_message_leaf_index(),
+            self.core.metrics.retry_queue_length(),
         );
 
         self.run_all(vec![checkpoint_relayer.spawn(), message_processor.spawn()])


### PR DESCRIPTION
This PR adds some prometheus gauges to track the various phases of messages and where they are according to agent state (primarily the relayer). The prime metric is `last_known_message_leaf_index` with the following phases:

```
 - dispatch: When a message is indexed and stored in the DB
 - signed_offchain_checkpoint: When a leaf index is known to be signed by a validator
 - inbox_checkpoint: When a leaf index is known to be checkpointed on the inbox
 - relayer_processed: When a leaf index was processed with CheckpointRelayer
 - processor_loop: The current leaf index in the MessageProcessor loop
 - message_processed: When a leaf index was processed as part of the regular MessageProcessor loop
```

Also added a gauge to track the retry queue length