### PR TITLE
Debugging testnet deployment

### DIFF
--- a/rust/agents/relayer/src/checkpoint_relayer.rs
+++ b/rust/agents/relayer/src/checkpoint_relayer.rs
@@ -124,7 +124,7 @@ impl CheckpointRelayer {
                 .submit_checkpoint(&latest_signed_checkpoint)
                 .await {
                     Ok(_) => (),
-                    Err(error) => {
+                    Err(_) => {
                         // Ignore errors as to not fail the process and just retry after some sleep
                         sleep(Duration::from_secs(self.submission_latency)).await;
                         return Ok(onchain_checkpoint_index)

--- a/rust/agents/relayer/src/checkpoint_relayer.rs
+++ b/rust/agents/relayer/src/checkpoint_relayer.rs
@@ -185,7 +185,10 @@ impl CheckpointRelayer {
             onchain_checkpoint_index + 1
         };
 
-        info!(onchain_checkpoint_index=onchain_checkpoint_index, "Starting CheckpointRelayer");
+        info!(
+            onchain_checkpoint_index = onchain_checkpoint_index,
+            "Starting CheckpointRelayer"
+        );
 
         loop {
             sleep(Duration::from_secs(self.polling_interval)).await;

--- a/rust/agents/relayer/src/message_processor.rs
+++ b/rust/agents/relayer/src/message_processor.rs
@@ -76,7 +76,7 @@ impl MessageProcessor {
         }
     }
 
-    #[instrument(ret, err, skip(self), level = "debug")]
+    #[instrument(ret, err, skip(self), level = "info")]
     async fn try_processing_message(
         &mut self,
         message_leaf_index: u32,

--- a/rust/agents/relayer/src/message_processor.rs
+++ b/rust/agents/relayer/src/message_processor.rs
@@ -76,7 +76,7 @@ impl MessageProcessor {
         }
     }
 
-    #[instrument(ret, err, skip(self), level = "info")]
+    #[instrument(ret, err, skip(self), fields(inbox_name=self.inbox.name()), level = "debug")]
     async fn try_processing_message(
         &mut self,
         message_leaf_index: u32,
@@ -151,74 +151,90 @@ impl MessageProcessor {
         }
     }
 
-    pub(crate) fn spawn(mut self) -> Instrumented<JoinHandle<Result<()>>> {
-        let span = info_span!("MessageProcessor");
-
+    #[instrument(ret, err, skip(self), fields(inbox_name=self.inbox.name()), level = "info")]
+    async fn main_loop(mut self) -> Result<()> {
         let mut message_leaf_index = 0;
-        tokio::spawn(async move {
-            loop {
-                self.processor_loop_gauge.set(message_leaf_index as i64);
-                self.retry_queue_length_gauge.set(self.retry_queue.len() as i64);
-                if self.db.retrieve_leaf_processing_status(message_leaf_index)?.is_some() {
-                    message_leaf_index += 1;
-                    continue
-                }
-                // Sleep to not fire too many view calls in a short duration
-                sleep(Duration::from_millis(20)).await;
+        loop {
+            self.processor_loop_gauge.set(message_leaf_index as i64);
+            self.retry_queue_length_gauge
+                .set(self.retry_queue.len() as i64);
+            if self
+                .db
+                .retrieve_leaf_processing_status(message_leaf_index)?
+                .is_some()
+            {
+                message_leaf_index += 1;
+                continue;
+            }
+            // Sleep to not fire too many view calls in a short duration
+            sleep(Duration::from_millis(20)).await;
 
-                match self.db.leaf_by_leaf_index(message_leaf_index)? {
-                    Some(_) => {
-                        // We have unseen messages to process
-                        info!(
-                            destination = self.inbox.local_domain(),
-                            leaf_index=message_leaf_index,
-                            "Process fresh leaf"
-                        );
-                        match self.try_processing_message(message_leaf_index).await? {
-                            MessageProcessingStatus::Processed => {
-                                self.processed_gauge.set(message_leaf_index as i64);
-                                message_leaf_index += 1
-                            },
-                            MessageProcessingStatus::NotYetCheckpointed => {
-                                // If we don't have an up to date checkpoint, sleep and try again
-                                sleep(Duration::from_secs(self.polling_interval)).await;
-                            }
-                            MessageProcessingStatus::NotDestinedForInbox => message_leaf_index += 1,
-                            MessageProcessingStatus::Error => {
-                                warn!(destination = self.inbox.local_domain(), leaf_index=message_leaf_index, "Message could not be processed, queue for retry");
-                                self.retry_queue
-                                    .push(MessageToRetry {
-                                        leaf_index: message_leaf_index,
-                                        time_to_retry: Reverse(Instant::now()),
-                                        retries: 0,
-                                    });
-                                message_leaf_index += 1;
-                            }
+            match self.db.leaf_by_leaf_index(message_leaf_index)? {
+                Some(_) => {
+                    // We have unseen messages to process
+                    info!(
+                        destination = self.inbox.local_domain(),
+                        leaf_index = message_leaf_index,
+                        "Process fresh leaf"
+                    );
+                    match self.try_processing_message(message_leaf_index).await? {
+                        MessageProcessingStatus::Processed => {
+                            self.processed_gauge.set(message_leaf_index as i64);
+                            message_leaf_index += 1
+                        }
+                        MessageProcessingStatus::NotYetCheckpointed => {
+                            // If we don't have an up to date checkpoint, sleep and try again
+                            sleep(Duration::from_secs(self.polling_interval)).await;
+                        }
+                        MessageProcessingStatus::NotDestinedForInbox => message_leaf_index += 1,
+                        MessageProcessingStatus::Error => {
+                            warn!(
+                                destination = self.inbox.local_domain(),
+                                leaf_index = message_leaf_index,
+                                "Message could not be processed, queue for retry"
+                            );
+                            self.retry_queue.push(MessageToRetry {
+                                leaf_index: message_leaf_index,
+                                time_to_retry: Reverse(Instant::now()),
+                                retries: 0,
+                            });
+                            message_leaf_index += 1;
                         }
                     }
-                    None => {
-                        // See if we have messages to retry
-                        if let Some(MessageToRetry{ time_to_retry, .. }) = self.retry_queue.peek() {
-                            // Since we use Reverse, we want time_to_retry to be smaller
-                            if time_to_retry < &Reverse(Instant::now()) {
-                                continue
-                            }
+                }
+                None => {
+                    // See if we have messages to retry
+                    if let Some(MessageToRetry { time_to_retry, .. }) = self.retry_queue.peek() {
+                        // Since we use Reverse, we want time_to_retry to be smaller
+                        if time_to_retry < &Reverse(Instant::now()) {
+                            continue;
                         }
-                        match self.retry_queue.pop() {
-                            Some(MessageToRetry { leaf_index, retries, .. }) => {
-                                info!(
-                                    destination = self.inbox.local_domain(),
-                                    leaf_index = leaf_index,
-                                    retries = retries,
-                                    retry_queue_length = self.retry_queue.len(),
-                                    "Retry processing of message"
-                                );
-                                match self.try_processing_message(leaf_index).await? {
-                                MessageProcessingStatus::NotDestinedForInbox | MessageProcessingStatus::NotYetCheckpointed => {
-                                    error!(leaf_index = leaf_index, "Somehow we tried to retry a message that cant be retried");
-                                    bail!("Somehow we tried to retry a message that cant be retried")
+                    }
+                    match self.retry_queue.pop() {
+                        Some(MessageToRetry {
+                            leaf_index,
+                            retries,
+                            ..
+                        }) => {
+                            info!(
+                                destination = self.inbox.local_domain(),
+                                leaf_index = leaf_index,
+                                retries = retries,
+                                retry_queue_length = self.retry_queue.len(),
+                                "Retry processing of message"
+                            );
+                            match self.try_processing_message(leaf_index).await? {
+                                MessageProcessingStatus::NotDestinedForInbox
+                                | MessageProcessingStatus::NotYetCheckpointed => {
+                                    error!(
+                                        leaf_index = leaf_index,
+                                        "Somehow we tried to retry a message that cant be retried"
+                                    );
+                                    bail!(
+                                        "Somehow we tried to retry a message that cant be retried"
+                                    )
                                 }
-                                MessageProcessingStatus::Processed => {},
+                                MessageProcessingStatus::Processed => {}
                                 MessageProcessingStatus::Error => {
                                     warn!(
                                         destination = self.inbox.local_domain(),
@@ -229,32 +245,39 @@ impl MessageProcessor {
                                     );
                                     if retries >= self.max_retries {
                                         error!(
-                                            destination = self.inbox.local_domain(),
-                                            leaf_index = leaf_index,
-                                            retries = retries,
-                                            retry_queue_length = self.retry_queue.len(),
-                                            "Maximum number of retries exceeded for processing message"
-                                        );
-                                        continue
+                                        destination = self.inbox.local_domain(),
+                                        leaf_index = leaf_index,
+                                        retries = retries,
+                                        retry_queue_length = self.retry_queue.len(),
+                                        "Maximum number of retries exceeded for processing message"
+                                    );
+                                        continue;
                                     }
                                     let retries = retries + 1;
-                                    let time_to_retry = Reverse(Instant::now() + Duration::from_secs(2u64.pow(retries as u32)));
-                                    self.retry_queue
-                                        .push(MessageToRetry{ leaf_index, time_to_retry, retries});
-                                },
+                                    let time_to_retry = Reverse(
+                                        Instant::now()
+                                            + Duration::from_secs(2u64.pow(retries as u32)),
+                                    );
+                                    self.retry_queue.push(MessageToRetry {
+                                        leaf_index,
+                                        time_to_retry,
+                                        retries,
+                                    });
+                                }
                             }
-                        },
-                            None => {
-                                // Nothing to do, just sleep
-                                sleep(Duration::from_secs(1)).await;
-                            }
+                        }
+                        None => {
+                            // Nothing to do, just sleep
+                            sleep(Duration::from_secs(1)).await;
                         }
                     }
                 }
-
-
             }
-        })
-        .instrument(span)
+        }
+    }
+
+    pub(crate) fn spawn(self) -> Instrumented<JoinHandle<Result<()>>> {
+        let span = info_span!("MessageProcessor");
+        tokio::spawn(async move { self.main_loop().await }).instrument(span)
     }
 }

--- a/rust/agents/validator/src/submit.rs
+++ b/rust/agents/validator/src/submit.rs
@@ -37,6 +37,8 @@ impl ValidatorSubmitter {
         let reorg_period = Some(self.reorg_period);
         tokio::spawn(async move {
             let mut current_index = self.checkpoint_syncer.latest_index().await?.unwrap_or_default();
+
+            info!(current_index=current_index, "Starting Validator");
             loop {
                 sleep(Duration::from_secs(self.interval)).await;
 

--- a/rust/tools/abacus-cli/src/subcommands/prove.rs
+++ b/rust/tools/abacus-cli/src/subcommands/prove.rs
@@ -134,7 +134,7 @@ impl ProveCommand {
         let provider = self
             .rpc
             .as_ref()
-            .map(|rpc| Provider::<Http>::try_from(rpc))
+            .map(Provider::<Http>::try_from)
             .transpose()?
             .unwrap_or_else(|| rpc::fetch_rpc_connection(destination).unwrap());
 

--- a/rust/tools/abacus-cli/src/subcommands/prove.rs
+++ b/rust/tools/abacus-cli/src/subcommands/prove.rs
@@ -134,7 +134,7 @@ impl ProveCommand {
         let provider = self
             .rpc
             .as_ref()
-            .map(|rpc| Provider::<Http>::try_from(rpc.as_ref()))
+            .map(|rpc| Provider::<Http>::try_from(rpc))
             .transpose()?
             .unwrap_or_else(|| rpc::fetch_rpc_connection(destination).unwrap());
 

--- a/rust/tools/kms-cli/src/main.rs
+++ b/rust/tools/kms-cli/src/main.rs
@@ -145,7 +145,7 @@ async fn _send_tx(signer: &AwsSigner<'_>, opts: &Opts) -> Result<()> {
         SubCommands::Info(_) => unreachable!(),
     };
 
-    let provider = Provider::<Http>::try_from(tx.rpc.as_ref())?;
+    let provider = Provider::<Http>::try_from(tx.rpc.clone())?;
 
     let tx_req = prep_tx_request(tx);
 

--- a/typescript/infra/src/agents/index.ts
+++ b/typescript/infra/src/agents/index.ts
@@ -176,7 +176,7 @@ export async function getAgentEnvVars<Networks extends ChainName>(
       chainNames.forEach((chainName) => {
         const key = new AgentAwsKey(agentConfig, role, chainName);
         envVars = envVars.concat(
-          configEnvVars(key.keyConfig, 'BASE', 'SIGNERS_'),
+          configEnvVars(key.keyConfig, 'BASE', `SIGNERS_${chainName.toUpperCase()}_`),
         );
       });
     }
@@ -232,7 +232,7 @@ function configEnvVars(
     if (typeof value === 'object') {
       envVars = [
         ...envVars,
-        ...configEnvVars(value, role, `${key.toUpperCase()}_`),
+        ...configEnvVars(value, role, `${key_name_prefix}${key.toUpperCase()}_`),
       ];
     } else {
       envVars.push(

--- a/typescript/infra/src/agents/index.ts
+++ b/typescript/infra/src/agents/index.ts
@@ -176,7 +176,7 @@ export async function getAgentEnvVars<Networks extends ChainName>(
       chainNames.forEach((chainName) => {
         const key = new AgentAwsKey(agentConfig, role, chainName);
         envVars = envVars.concat(
-          configEnvVars(key.keyConfig, 'BASE', `SIGNERS_${chainName.toUpperCase()}_`),
+          configEnvVars(key.keyConfig, 'BASE', `SIGNERS_${outboxChainName.toUpperCase()}_`),
         );
       });
     }

--- a/typescript/sdk/src/core/environments/index.ts
+++ b/typescript/sdk/src/core/environments/index.ts
@@ -1,4 +1,5 @@
 import { addresses as test } from './test';
+import { addresses as testnet } from './testnet';
 import { ChainName } from '../../';
 import { CoreContractAddresses } from '../';
 export const addresses: Record<
@@ -6,4 +7,5 @@ export const addresses: Record<
   Partial<Record<ChainName, CoreContractAddresses>>
 > = {
   test,
+  testnet
 };


### PR DESCRIPTION
This PR adds the following changes:
- Ignores errors during checkpoint submission in the relayer so it doesn't bring down the whole process
- Pulls out the loops of CheckpointRelayer and MessageProcessor so that tracing spans with the inbox name are actually visible
- Upgrades ethers-rs