### PR TITLE
Consider checkpoint relaying costs in interchain gas calculator, only require `handle` gas cost

### DIFF
--- a/typescript/sdk/package.json
+++ b/typescript/sdk/package.json
@@ -23,6 +23,7 @@
     "fs": "0.0.1-security",
     "mocha": "^9.2.2",
     "prettier": "^2.4.1",
+    "sinon": "^13.0.2",
     "typescript": "^4.4.3"
   },
   "dependencies": {

--- a/typescript/sdk/package.json
+++ b/typescript/sdk/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "tsc",
     "check": "tsc --noEmit",
-    "prettier": "prettier --write ./src",
+    "prettier": "prettier --write ./src ./test",
     "prepublishOnly": "npm run build",
     "test": "mocha --config .mocharc.json './test/**/*.test.ts'"
   },

--- a/typescript/sdk/src/gas/calculator.ts
+++ b/typescript/sdk/src/gas/calculator.ts
@@ -68,12 +68,12 @@ export class InterchainGasCalculator {
   }
 
   /**
-   * Calculates the estimated payment given an amount of gas the message's
-   * recipient `handle` function is expected to use denominated in the native
+   * Given an amount of gas the message's recipient `handle` function is expected
+   * to use, calculates the estimated payment denominated in the native
    * token of the origin chain. Considers the exchange rate between the native
    * tokens of the origin and destination chains, the suggested gas price on
    * the destination chain, gas costs incurred by a relayer when submitting a signed
-   * checkpoint to the destination chain, and the overhead gas cost of processing
+   * checkpoint to the destination chain, and the overhead gas cost in Inbox of processing
    * a message. Applies the multiplier `paymentEstimateMultiplier`.
    * @param originDomain The domain of the origin chain.
    * @param destinationDomain The domain of the destination chain.

--- a/typescript/sdk/src/gas/calculator.ts
+++ b/typescript/sdk/src/gas/calculator.ts
@@ -232,7 +232,9 @@ export class InterchainGasCalculator {
    * @returns The estimated gas required by the message's recipient handle function
    * on the destination chain.
    */
-  async estimateHandleGasForMessage(message: ParsedMessage): Promise<BigNumber> {
+  async estimateHandleGasForMessage(
+    message: ParsedMessage,
+  ): Promise<BigNumber> {
     const provider = this.core.mustGetProvider(message.destination);
     const inbox = this.core.mustGetInbox(message.origin, message.destination);
 
@@ -266,7 +268,10 @@ export class InterchainGasCalculator {
    * @returns An estimated gas amount a relayer will spend when submitting a signed
    * checkpoint to the destination domain.
    */
-  async checkpointRelayGas(originDomain: number, destinationDomain: number): Promise<BigNumber> {
+  async checkpointRelayGas(
+    originDomain: number,
+    destinationDomain: number,
+  ): Promise<BigNumber> {
     // The gas used if the quorum threshold of a signed checkpoint is zero.
     // Includes intrinsic gas and all other gas that does not scale with the
     // number of signatures. Note this does not consider differences in intrinsic gas for
@@ -277,11 +282,13 @@ export class InterchainGasCalculator {
     // Really observed to be about 8350, but rounding up for safety.
     const gasPerSignature = 9_000;
 
-    const validatorManager = this.core.mustGetInboxValidatorManager(originDomain, destinationDomain);
+    const validatorManager = this.core.mustGetInboxValidatorManager(
+      originDomain,
+      destinationDomain,
+    );
     const threshold = await validatorManager.threshold();
 
-    return threshold.mul(gasPerSignature)
-      .add(baseGasAmount);
+    return threshold.mul(gasPerSignature).add(baseGasAmount);
   }
 
   /**

--- a/typescript/sdk/src/gas/calculator.ts
+++ b/typescript/sdk/src/gas/calculator.ts
@@ -294,9 +294,8 @@ export class InterchainGasCalculator {
 
   /**
    * @returns A generous estimation of the gas consumption of all prove and process
-   * operations in Inbox.sol, excluding:
-   * 1. Intrinsic gas.
-   * 2. Any gas consumed within a `handle` function when processing a message once called.
+   * operations within Inbox.sol, including intrinsic gas. Does not include any gas
+   * consumed within a message's recipient `handle` function.
    */
   get inboxProcessOverheadGas(): BigNumber {
     // This does not consider that different domains can possibly have different gas costs.
@@ -306,8 +305,8 @@ export class InterchainGasCalculator {
     // This number was arrived at by estimating the proving and processing of a message
     // whose body was small and whose recipient contract included only an empty fallback
     // function. The estimated gas cost was 86777, which included the intrinsic cost.
-    // 100,000 is chosen as a generous buffer for safety.
-    return BigNumber.from(100_000);
+    // 130,000 is chosen as a generous buffer for safety.
+    return BigNumber.from(130_000);
   }
 
   /**

--- a/typescript/sdk/src/gas/calculator.ts
+++ b/typescript/sdk/src/gas/calculator.ts
@@ -227,7 +227,7 @@ export class InterchainGasCalculator {
    * 1. The estimated gas consumption of a direct call to the `handle`
    *    function of the recipient address using the correct parameters and
    *    setting the `from` address of the transaction to the address of the inbox.
-   * 2. A buffer to account for inaccuracies in the above estimations.
+   * 2. A buffer to account for inaccuracies in the above estimation.
    * @param message The message to estimate recipient `handle` gas usage for.
    * @returns The estimated gas required by the message's recipient handle function
    * on the destination chain.
@@ -255,8 +255,9 @@ export class InterchainGasCalculator {
     });
 
     // Subtract intrinsic gas, which is included in directHandleCallGas.
-    // Note in the intrinsic gas will always be higher than this.intrinsicGas
-    // due to calldata costs, but that's desired because it results in a generous estimate here.
+    // Note the "real" intrinsic gas will always be higher than this.intrinsicGas
+    // due to calldata costs, but this is desired because it results in a generous
+    // final estimate.
     return directHandleCallGas
       .add(this.messageGasEstimateBuffer)
       .sub(this.intrinsicGas);
@@ -277,7 +278,7 @@ export class InterchainGasCalculator {
     // number of signatures. Note this does not consider differences in intrinsic gas for
     // different chains.
     // Derived by observing the amount of gas consumed for a quorum of 1 (~86800 gas),
-    // subtracting a the scaling gas per signature, and rounding up for safety.
+    // subtracting the scaling gas per signature, and rounding up for safety.
     const baseGasAmount = 80_000;
     // Really observed to be about 8350, but rounding up for safety.
     const gasPerSignature = 9_000;

--- a/typescript/sdk/test/gas/calculator.test.ts
+++ b/typescript/sdk/test/gas/calculator.test.ts
@@ -55,15 +55,13 @@ describe('InterchainGasCalculator', () => {
       provider.setMethodResolveValue('getGasPrice', BigNumber.from(10));
 
       // Stub the checkpoint relay gas cost
-      const checkpointRelayGas = BigNumber.from(100_000);
       sinon
         .stub(calculator, 'checkpointRelayGas')
-        .returns(Promise.resolve(checkpointRelayGas));
+        .returns(Promise.resolve(BigNumber.from(100_000)));
       // Stub the inbox process overhead gas
-      const inboxProcessOverheadGas = BigNumber.from(100_000);
       sinon
         .stub(calculator, 'inboxProcessOverheadGas')
-        .returns(inboxProcessOverheadGas);
+        .returns(BigNumber.from(100_000));
 
       const estimatedPayment =
         await calculator.estimatePaymentForHandleGasAmount(
@@ -90,15 +88,13 @@ describe('InterchainGasCalculator', () => {
         .stub(calculator, 'suggestedGasPrice')
         .returns(Promise.resolve(BigNumber.from(10)));
       // Stub the checkpoint relay gas cost
-      const checkpointRelayGas = BigNumber.from(100_000);
       sinon
         .stub(calculator, 'checkpointRelayGas')
-        .returns(Promise.resolve(checkpointRelayGas));
+        .returns(Promise.resolve(BigNumber.from(100_000)));
       // Stub the inbox process overhead gas
-      const inboxProcessOverheadGas = BigNumber.from(100_000);
       sinon
         .stub(calculator, 'inboxProcessOverheadGas')
-        .returns(inboxProcessOverheadGas);
+        .returns(BigNumber.from(100_000));
 
       const zeroAddressBytes32 = utils.addressToBytes32(
         ethers.constants.AddressZero,

--- a/typescript/sdk/test/utils.ts
+++ b/typescript/sdk/test/utils.ts
@@ -1,4 +1,5 @@
-import { ethers, FixedNumber } from 'ethers';
+import { FixedNumber, ethers } from 'ethers';
+
 import { NameOrDomain } from '../src';
 
 const ZERO_ADDRESS = ethers.constants.AddressZero;

--- a/yarn.lock
+++ b/yarn.lock
@@ -198,6 +198,7 @@ __metadata:
     fs: 0.0.1-security
     mocha: ^9.2.2
     prettier: ^2.4.1
+    sinon: ^13.0.2
     typescript: ^4.4.3
   languageName: unknown
   linkType: soft
@@ -3243,6 +3244,42 @@ __metadata:
   version: 0.14.0
   resolution: "@sindresorhus/is@npm:0.14.0"
   checksum: 971e0441dd44ba3909b467219a5e242da0fc584048db5324cfb8048148fa8dcc9d44d71e3948972c4f6121d24e5da402ef191420d1266a95f713bb6d6e59c98a
+  languageName: node
+  linkType: hard
+
+"@sinonjs/commons@npm:^1.6.0, @sinonjs/commons@npm:^1.7.0, @sinonjs/commons@npm:^1.8.3":
+  version: 1.8.3
+  resolution: "@sinonjs/commons@npm:1.8.3"
+  dependencies:
+    type-detect: 4.0.8
+  checksum: 6159726db5ce6bf9f2297f8427f7ca5b3dff45b31e5cee23496f1fa6ef0bb4eab878b23fb2c5e6446381f6a66aba4968ef2fc255c1180d753d4b8c271636a2e5
+  languageName: node
+  linkType: hard
+
+"@sinonjs/fake-timers@npm:>=5, @sinonjs/fake-timers@npm:^9.1.2":
+  version: 9.1.2
+  resolution: "@sinonjs/fake-timers@npm:9.1.2"
+  dependencies:
+    "@sinonjs/commons": ^1.7.0
+  checksum: 7d3aef54e17c1073101cb64d953157c19d62a40e261a30923fa1ee337b049c5f29cc47b1f0c477880f42b5659848ba9ab897607ac8ea4acd5c30ddcfac57fca6
+  languageName: node
+  linkType: hard
+
+"@sinonjs/samsam@npm:^6.1.1":
+  version: 6.1.1
+  resolution: "@sinonjs/samsam@npm:6.1.1"
+  dependencies:
+    "@sinonjs/commons": ^1.6.0
+    lodash.get: ^4.4.2
+    type-detect: ^4.0.8
+  checksum: a09b0914bf573f0da82bd03c64ba413df81a7c173818dc3f0a90c2652240ac835ef583f4d52f0b215e626633c91a4095c255e0669f6ead97241319f34f05e7fc
+  languageName: node
+  linkType: hard
+
+"@sinonjs/text-encoding@npm:^0.7.1":
+  version: 0.7.1
+  resolution: "@sinonjs/text-encoding@npm:0.7.1"
+  checksum: 130de0bb568c5f8a611ec21d1a4e3f80ab0c5ec333010f49cfc1adc5cba6d8808699c8a587a46b0f0b016a1f4c1389bc96141e773e8460fcbb441875b2e91ba7
   languageName: node
   linkType: hard
 
@@ -6522,7 +6559,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"diff@npm:5.0.0":
+"diff@npm:5.0.0, diff@npm:^5.0.0":
   version: 5.0.0
   resolution: "diff@npm:5.0.0"
   checksum: f19fe29284b633afdb2725c2a8bb7d25761ea54d321d8e67987ac851c5294be4afeab532bd84531e02583a3fe7f4014aa314a3eda84f5590e7a9e6b371ef3b46
@@ -10171,6 +10208,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"just-extend@npm:^4.0.2":
+  version: 4.2.1
+  resolution: "just-extend@npm:4.2.1"
+  checksum: ff9fdede240fad313efeeeb68a660b942e5586d99c0058064c78884894a2690dc09bba44c994ad4e077e45d913fef01a9240c14a72c657b53687ac58de53b39c
+  languageName: node
+  linkType: hard
+
 "keccak@npm:3.0.1":
   version: 3.0.1
   resolution: "keccak@npm:3.0.1"
@@ -10574,6 +10618,13 @@ __metadata:
   version: 4.2.0
   resolution: "lodash.assign@npm:4.2.0"
   checksum: 75bbc6733c9f577c448031b4051f990f068802708891f94be9d4c2faffd6a9ec67a2c49671dafc908a068d35687765464853282842b4560b662e6c903d11cc90
+  languageName: node
+  linkType: hard
+
+"lodash.get@npm:^4.4.2":
+  version: 4.4.2
+  resolution: "lodash.get@npm:4.4.2"
+  checksum: e403047ddb03181c9d0e92df9556570e2b67e0f0a930fcbbbd779370972368f5568e914f913e93f3b08f6d492abc71e14d4e9b7a18916c31fa04bd2306efe545
   languageName: node
   linkType: hard
 
@@ -11449,6 +11500,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nise@npm:^5.1.1":
+  version: 5.1.1
+  resolution: "nise@npm:5.1.1"
+  dependencies:
+    "@sinonjs/commons": ^1.8.3
+    "@sinonjs/fake-timers": ">=5"
+    "@sinonjs/text-encoding": ^0.7.1
+    just-extend: ^4.0.2
+    path-to-regexp: ^1.7.0
+  checksum: d8be29e84a014743c9a10f428fac86f294ac5f92bed1f606fe9b551e935f494d8e0ce1af8a12673c6014010ec7f771f2d48aa5c8e116f223eb4f40c5e1ab44b3
+  languageName: node
+  linkType: hard
+
 "node-addon-api@npm:^2.0.0":
   version: 2.0.2
   resolution: "node-addon-api@npm:2.0.2"
@@ -12135,6 +12199,15 @@ __metadata:
   version: 0.1.7
   resolution: "path-to-regexp@npm:0.1.7"
   checksum: 69a14ea24db543e8b0f4353305c5eac6907917031340e5a8b37df688e52accd09e3cebfe1660b70d76b6bd89152f52183f28c74813dbf454ba1a01c82a38abce
+  languageName: node
+  linkType: hard
+
+"path-to-regexp@npm:^1.7.0":
+  version: 1.8.0
+  resolution: "path-to-regexp@npm:1.8.0"
+  dependencies:
+    isarray: 0.0.1
+  checksum: 709f6f083c0552514ef4780cb2e7e4cf49b0cc89a97439f2b7cc69a608982b7690fb5d1720a7473a59806508fc2dae0be751ba49f495ecf89fd8fbc62abccbcd
   languageName: node
   linkType: hard
 
@@ -13500,6 +13573,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sinon@npm:^13.0.2":
+  version: 13.0.2
+  resolution: "sinon@npm:13.0.2"
+  dependencies:
+    "@sinonjs/commons": ^1.8.3
+    "@sinonjs/fake-timers": ^9.1.2
+    "@sinonjs/samsam": ^6.1.1
+    diff: ^5.0.0
+    nise: ^5.1.1
+    supports-color: ^7.2.0
+  checksum: 237f21c8c4a8b31574c71b1b9f4c0f74a63dde5c0e86bd116effa4ce63c52467bd45fb4034a8fa32656a7919d9b19fc7b108ca9e1e6e3144f3735da96dad2877
+  languageName: node
+  linkType: hard
+
 "slash@npm:^1.0.0":
   version: 1.0.0
   resolution: "slash@npm:1.0.0"
@@ -14146,7 +14233,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"supports-color@npm:^7.1.0":
+"supports-color@npm:^7.1.0, supports-color@npm:^7.2.0":
   version: 7.2.0
   resolution: "supports-color@npm:7.2.0"
   dependencies:
@@ -14626,7 +14713,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-detect@npm:^4.0.0, type-detect@npm:^4.0.5":
+"type-detect@npm:4.0.8, type-detect@npm:^4.0.0, type-detect@npm:^4.0.5, type-detect@npm:^4.0.8":
   version: 4.0.8
   resolution: "type-detect@npm:4.0.8"
   checksum: 62b5628bff67c0eb0b66afa371bd73e230399a8d2ad30d852716efcc4656a7516904570cd8631a49a3ce57c10225adf5d0cbdcb47f6b0255fe6557c453925a15


### PR DESCRIPTION
Fixes #386
* Adds `sinon` to help with mocking in the SDK tests
* Changes the InterchainGasCalculator to require the gas amount that the recipient `handle` function is expected to consume. Previously, intrinsic gas and gas costs incurred by the Inbox (like the merkle proof) were expected to be accounted for in the amount provided to `estimatePaymentForHandleGasAmount`, which is a poor UX
* Considers the cost incurred by relayers when relaying a signed checkpoint.