### PR TITLE
Fix import for infra test environment

### DIFF
--- a/typescript/infra/config/environments/test/index.ts
+++ b/typescript/infra/config/environments/test/index.ts
@@ -17,7 +17,7 @@ export const environment: CoreEnvironmentConfig<TestNetworks> = {
   // NOTE: Does not work from hardhat.config.ts
   getMultiProvider: async () => {
     const hre = await import('hardhat');
-    await import('@nomiclabs/hardhat-ethers')
+    await import('@nomiclabs/hardhat-ethers');
     const [signer] = await hre.ethers.getSigners();
     return utils.getMultiProviderFromConfigAndSigner(testConfigs, signer);
   },

--- a/typescript/infra/config/environments/test/index.ts
+++ b/typescript/infra/config/environments/test/index.ts
@@ -17,6 +17,7 @@ export const environment: CoreEnvironmentConfig<TestNetworks> = {
   // NOTE: Does not work from hardhat.config.ts
   getMultiProvider: async () => {
     const hre = await import('hardhat');
+    await import('@nomiclabs/hardhat-ethers')
     const [signer] = await hre.ethers.getSigners();
     return utils.getMultiProviderFromConfigAndSigner(testConfigs, signer);
   },


### PR DESCRIPTION
When running infra scripts, typescript complains that ethers is not defined on hre. That's only try after importing `hardhat-ethers`