### PR TITLE
Fix ENV var for relayer signer aws keys

### DIFF
--- a/typescript/infra/src/agents/index.ts
+++ b/typescript/infra/src/agents/index.ts
@@ -171,12 +171,12 @@ export async function getAgentEnvVars<Networks extends ChainName>(
       role === KEY_ROLE_ENUM.Kathy
     ) {
       chainNames.forEach((chainName) => {
-        const key = new AgentAwsKey(agentConfig, role, chainName);
+        const key = new AgentAwsKey(agentConfig, role, outboxChainName);
         envVars = envVars.concat(
           configEnvVars(
             key.keyConfig,
             'BASE',
-            `SIGNERS_${outboxChainName.toUpperCase()}_`,
+            `SIGNERS_${chainName.toUpperCase()}_`,
           ),
         );
       });


### PR DESCRIPTION
When I "fixed" this last time, I mixed up the order .... 

Tested this by giving me the optimismkovan relayer env vars and it ran and succeeded nicely. Which unfortunately doesn't help me understand why the remote agent didnt do it