### PR TITLE
Fix infra test deploy

### DIFF
--- a/typescript/infra/hardhat.config.ts
+++ b/typescript/infra/hardhat.config.ts
@@ -74,10 +74,7 @@ task('abacus', 'Deploys abacus on top of an already running Hardhat Network')
       signer,
     );
 
-    const deployer = new AbacusCoreDeployer(
-      multiProvider,
-      config.core,
-    );
+    const deployer = new AbacusCoreDeployer(multiProvider, config.core);
     const addresses = await deployer.deploy();
 
     // Write configs

--- a/typescript/infra/hardhat.config.ts
+++ b/typescript/infra/hardhat.config.ts
@@ -76,7 +76,7 @@ task('abacus', 'Deploys abacus on top of an already running Hardhat Network')
 
     const deployer = new AbacusCoreDeployer(
       multiProvider,
-      config.core.validatorManagers,
+      config.core,
     );
     const addresses = await deployer.deploy();
 

--- a/typescript/infra/package.json
+++ b/typescript/infra/package.json
@@ -20,8 +20,8 @@
     "test": "hardhat test",
     "check": "tsc --noEmit",
     "node": "hardhat node",
-    "abacus": "hardhat abacus --environment test",
-    "kathy": "hardhat kathy --environment test --network localhost",
+    "abacus": "hardhat abacus --network localhost",
+    "kathy": "hardhat kathy --network localhost",
     "prettier": "prettier --write *.ts ./src ./config ./scripts ./test"
   },
   "license": "MIT OR Apache-2.0",


### PR DESCRIPTION
This PR fixes some minor things from the recent refactor. As `getCoreEnvironmentConfig` is not currently typed, passing the config was wrong and now that the infra hardhat tasks basically assume test environment (since that's how the signer for the multiprovider is deduced),  some args can be dropped 