### PR TITLE
Remove `TypedMemView` from `core` contracts

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: .//node_modules
-          key: ${{ runner.os }}-yarn-cache3-${{ hashFiles('./yarn.lock') }}
+          key: ${{ runner.os }}-yarn-cache4-${{ hashFiles('./yarn.lock') }}
 
       - name: yarn-install
         # Check out the lockfile from main, reinstall, and then
@@ -43,7 +43,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .//node_modules
-          key: ${{ runner.os }}-yarn-cache3-${{ hashFiles('./yarn.lock') }}
+          key: ${{ runner.os }}-yarn-cache4-${{ hashFiles('./yarn.lock') }}
 
       - name: build-cache
         uses: actions/cache@v2
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: .//node_modules
-          key: ${{ runner.os }}-yarn-cache3-${{ hashFiles('./yarn.lock') }}
+          key: ${{ runner.os }}-yarn-cache4-${{ hashFiles('./yarn.lock') }}
 
       - name: prettier
         run: |

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
         with:
-          path: .//node_modules
+          path: '**/node_modules'
           key: ${{ runner.os }}-yarn-cache4-${{ hashFiles('./yarn.lock') }}
 
       - name: yarn-install
@@ -42,7 +42,7 @@ jobs:
       - name: yarn-cache
         uses: actions/cache@v2
         with:
-          path: .//node_modules
+          path: '**/node_modules'
           key: ${{ runner.os }}-yarn-cache4-${{ hashFiles('./yarn.lock') }}
 
       - name: build-cache
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
         with:
-          path: .//node_modules
+          path: '**/node_modules'
           key: ${{ runner.os }}-yarn-cache4-${{ hashFiles('./yarn.lock') }}
 
       - name: prettier

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@abacus-network/monorepo",
   "scripts": {
-    "build": "tree node_modules && yarn workspaces foreach --parallel --topological run build",
+    "build": "yarn workspaces foreach --parallel --topological run build",
     "prettier": "yarn workspaces foreach --parallel run prettier"
   },
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@abacus-network/monorepo",
   "scripts": {
-    "build": "yarn workspaces foreach --parallel --topological run build",
+    "build": "tree node_modules && yarn workspaces foreach --parallel --topological run build",
     "prettier": "yarn workspaces foreach --parallel run prettier"
   },
   "workspaces": [

--- a/solidity/apps/package.json
+++ b/solidity/apps/package.json
@@ -29,7 +29,7 @@
   },
   "scripts": {
     "prettier": "prettier --write ./contracts ./test",
-    "build": "hardhat compile && hardhat typechain && tsc && npm run copy-types",
+    "build": "tree node_modules/@openzeppelin && hardhat compile && hardhat typechain && tsc && npm run copy-types",
     "copy-types": "cp types/*.d.ts dist/",
     "coverage": "hardhat coverage",
     "test": "hardhat test"

--- a/solidity/apps/package.json
+++ b/solidity/apps/package.json
@@ -29,7 +29,7 @@
   },
   "scripts": {
     "prettier": "prettier --write ./contracts ./test",
-    "build": "tree ./node_modules && hardhat compile && hardhat typechain && tsc && npm run copy-types",
+    "build": "yarn why @openzeppelin/contracts && hardhat compile && hardhat typechain && tsc && npm run copy-types",
     "copy-types": "cp types/*.d.ts dist/",
     "coverage": "hardhat coverage",
     "test": "hardhat test"

--- a/solidity/apps/package.json
+++ b/solidity/apps/package.json
@@ -29,7 +29,7 @@
   },
   "scripts": {
     "prettier": "prettier --write ./contracts ./test",
-    "build": "tree node_modules/@openzeppelin && hardhat compile && hardhat typechain && tsc && npm run copy-types",
+    "build": "tree ./node_modules && hardhat compile && hardhat typechain && tsc && npm run copy-types",
     "copy-types": "cp types/*.d.ts dist/",
     "coverage": "hardhat coverage",
     "test": "hardhat test"
@@ -37,7 +37,7 @@
   "license": "MIT OR Apache-2.0",
   "dependencies": {
     "@abacus-network/app": "^0.1.1",
-    "@abacus-network/core": "^0.1.1",
+    "@abacus-network/core": "^0.1.2",
     "@abacus-network/hardhat": "^0.1.1",
     "@abacus-network/utils": "^0.1.1",
     "@openzeppelin/contracts": "~3.4.2",

--- a/solidity/apps/package.json
+++ b/solidity/apps/package.json
@@ -29,7 +29,7 @@
   },
   "scripts": {
     "prettier": "prettier --write ./contracts ./test",
-    "build": "yarn why @openzeppelin/contracts && hardhat compile && hardhat typechain && tsc && npm run copy-types",
+    "build": "hardhat compile && hardhat typechain && tsc && npm run copy-types",
     "copy-types": "cp types/*.d.ts dist/",
     "coverage": "hardhat coverage",
     "test": "hardhat test"

--- a/solidity/apps/package.json
+++ b/solidity/apps/package.json
@@ -37,7 +37,7 @@
   "license": "MIT OR Apache-2.0",
   "dependencies": {
     "@abacus-network/app": "^0.1.1",
-    "@abacus-network/core": "^0.1.2",
+    "@abacus-network/core": "^0.1.1",
     "@abacus-network/hardhat": "^0.1.1",
     "@abacus-network/utils": "^0.1.1",
     "@openzeppelin/contracts": "~3.4.2",

--- a/solidity/core/contracts/AbacusConnectionManager.sol
+++ b/solidity/core/contracts/AbacusConnectionManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity >=0.8.0;
 pragma abicoder v2;
 
 // ============ Internal Imports ============
@@ -9,8 +9,7 @@ import {IAbacusConnectionManager} from "../interfaces/IAbacusConnectionManager.s
 
 // ============ External Imports ============
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
-import {SafeMath} from "@openzeppelin/contracts/math/SafeMath.sol";
-import {EnumerableSet} from "@openzeppelin/contracts/utils/EnumerableSet.sol";
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
 /**
  * @title AbacusConnectionManager
@@ -19,7 +18,6 @@ import {EnumerableSet} from "@openzeppelin/contracts/utils/EnumerableSet.sol";
  * domains.
  */
 contract AbacusConnectionManager is IAbacusConnectionManager, Ownable {
-    using SafeMath for uint256;
     using EnumerableSet for EnumerableSet.AddressSet;
 
     // ============ Public Storage ============
@@ -129,7 +127,7 @@ contract AbacusConnectionManager is IAbacusConnectionManager, Ownable {
         ];
         uint256 length = _inboxes.length();
         address[] memory ret = new address[](length);
-        for (uint256 i = 0; i < length; i = i.add(1)) {
+        for (uint256 i = 0; i < length; i += 1) {
             ret[i] = _inboxes.at(i);
         }
         return ret;

--- a/solidity/core/contracts/Common.sol
+++ b/solidity/core/contracts/Common.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity >=0.8.0;
 
 // ============ Internal Imports ============
 import {ICommon} from "../interfaces/ICommon.sol";

--- a/solidity/core/contracts/Common.sol
+++ b/solidity/core/contracts/Common.sol
@@ -68,9 +68,7 @@ abstract contract Common is ICommon, OwnableUpgradeable {
 
     // ============ Initializer ============
 
-    function __Common_initialize(address _validatorManager)
-        internal
-    {
+    function __Common_initialize(address _validatorManager) internal {
         // initialize owner
         __Ownable_init();
         _setValidatorManager(_validatorManager);

--- a/solidity/core/contracts/Common.sol
+++ b/solidity/core/contracts/Common.sol
@@ -70,7 +70,6 @@ abstract contract Common is ICommon, OwnableUpgradeable {
 
     function __Common_initialize(address _validatorManager)
         internal
-        initializer
     {
         // initialize owner
         __Ownable_init();

--- a/solidity/core/contracts/Inbox.sol
+++ b/solidity/core/contracts/Inbox.sol
@@ -156,7 +156,7 @@ contract Inbox is IInbox, Version0, Common {
         // update message status as processed
         messages[_messageHash] = MessageStatus.Processed;
 
-        IMessageRecipient(recipient.toAddress()).handle(origin, sender, body);
+        IMessageRecipient(recipient.bytes32ToAddress()).handle(origin, sender, body);
         // emit process results
         emit Process(_messageHash);
     }

--- a/solidity/core/contracts/Inbox.sol
+++ b/solidity/core/contracts/Inbox.sol
@@ -145,8 +145,14 @@ contract Inbox is IInbox, Version0, Common {
 
         // update message status as processed
         messages[_messageHash] = MessageStatus.Processed;
-        IMessageRecipient _recipient = IMessageRecipient(_message.recipientAddress());
-        _recipient.handle(_message.origin(), _message.sender(), _message.body());
+        IMessageRecipient _recipient = IMessageRecipient(
+            _message.recipientAddress()
+        );
+        _recipient.handle(
+            _message.origin(),
+            _message.sender(),
+            _message.body()
+        );
         // emit process results
         emit Process(_messageHash);
     }

--- a/solidity/core/contracts/Inbox.sol
+++ b/solidity/core/contracts/Inbox.sol
@@ -8,8 +8,6 @@ import {MerkleLib} from "../libs/Merkle.sol";
 import {Message} from "../libs/Message.sol";
 import {IMessageRecipient} from "../interfaces/IMessageRecipient.sol";
 import {IInbox} from "../interfaces/IInbox.sol";
-// ============ External Imports ============
-import {TypedMemView} from "@summa-tx/memview-sol/contracts/TypedMemView.sol";
 
 /**
  * @title Inbox
@@ -21,8 +19,6 @@ contract Inbox is IInbox, Version0, Common {
     // ============ Libraries ============
 
     using MerkleLib for MerkleLib.Tree;
-    using TypedMemView for bytes;
-    using TypedMemView for bytes29;
     using Message for bytes29;
 
     // ============ Enums ============

--- a/solidity/core/contracts/Inbox.sol
+++ b/solidity/core/contracts/Inbox.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity >=0.8.0;
 
 // ============ Internal Imports ============
 import {Version0} from "./Version0.sol";
@@ -19,7 +19,7 @@ contract Inbox is IInbox, Version0, Common {
     // ============ Libraries ============
 
     using MerkleLib for MerkleLib.Tree;
-    using Message for bytes29;
+    using Message for bytes;
 
     // ============ Enums ============
 
@@ -140,14 +140,13 @@ contract Inbox is IInbox, Version0, Common {
      * @param _messageHash keccak256 hash of the message
      */
     function _process(bytes calldata _message, bytes32 _messageHash) internal {
-        bytes29 _m = _message.ref(0);
         // ensure message was meant for this domain
-        require(_m.destination() == localDomain, "!destination");
+        require(_message.destination() == localDomain, "!destination");
 
         // update message status as processed
         messages[_messageHash] = MessageStatus.Processed;
-        IMessageRecipient _recipient = IMessageRecipient(_m.recipientAddress());
-        _recipient.handle(_m.origin(), _m.sender(), _m.body().clone());
+        IMessageRecipient _recipient = IMessageRecipient(_message.recipientAddress());
+        _recipient.handle(_message.origin(), _message.sender(), _message.body());
         // emit process results
         emit Process(_messageHash);
     }

--- a/solidity/core/contracts/Inbox.sol
+++ b/solidity/core/contracts/Inbox.sol
@@ -156,7 +156,11 @@ contract Inbox is IInbox, Version0, Common {
         // update message status as processed
         messages[_messageHash] = MessageStatus.Processed;
 
-        IMessageRecipient(recipient.bytes32ToAddress()).handle(origin, sender, body);
+        IMessageRecipient(recipient.bytes32ToAddress()).handle(
+            origin,
+            sender,
+            body
+        );
         // emit process results
         emit Process(_messageHash);
     }

--- a/solidity/core/contracts/Inbox.sol
+++ b/solidity/core/contracts/Inbox.sol
@@ -6,6 +6,7 @@ import {Version0} from "./Version0.sol";
 import {Common} from "./Common.sol";
 import {MerkleLib} from "../libs/Merkle.sol";
 import {Message} from "../libs/Message.sol";
+import {TypeCasts} from "../libs/TypeCasts.sol";
 import {IMessageRecipient} from "../interfaces/IMessageRecipient.sol";
 import {IInbox} from "../interfaces/IInbox.sol";
 
@@ -20,6 +21,7 @@ contract Inbox is IInbox, Version0, Common {
 
     using MerkleLib for MerkleLib.Tree;
     using Message for bytes;
+    using TypeCasts for bytes32;
 
     // ============ Enums ============
 
@@ -112,7 +114,7 @@ contract Inbox is IInbox, Version0, Common {
         require(entered == 1, "!reentrant");
         entered = 0;
 
-        bytes32 _messageHash = keccak256(abi.encodePacked(_message, _index));
+        bytes32 _messageHash = _message.leaf(_index);
         // ensure that message has not been processed
         require(
             messages[_messageHash] == MessageStatus.None,
@@ -140,19 +142,21 @@ contract Inbox is IInbox, Version0, Common {
      * @param _messageHash keccak256 hash of the message
      */
     function _process(bytes calldata _message, bytes32 _messageHash) internal {
+        (
+            uint32 origin,
+            bytes32 sender,
+            uint32 destination,
+            bytes32 recipient,
+            bytes calldata body
+        ) = _message.destructure();
+
         // ensure message was meant for this domain
-        require(_message.destination() == localDomain, "!destination");
+        require(destination == localDomain, "!destination");
 
         // update message status as processed
         messages[_messageHash] = MessageStatus.Processed;
-        IMessageRecipient _recipient = IMessageRecipient(
-            _message.recipientAddress()
-        );
-        _recipient.handle(
-            _message.origin(),
-            _message.sender(),
-            _message.body()
-        );
+
+        IMessageRecipient(recipient.toAddress()).handle(origin, sender, body);
         // emit process results
         emit Process(_messageHash);
     }

--- a/solidity/core/contracts/InterchainGasPaymaster.sol
+++ b/solidity/core/contracts/InterchainGasPaymaster.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity >=0.8.0;
 
 // ============ Internal Imports ============
 import {IInterchainGasPaymaster} from "../interfaces/IInterchainGasPaymaster.sol";

--- a/solidity/core/contracts/Merkle.sol
+++ b/solidity/core/contracts/Merkle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity >=0.8.0;
 
 // ============ Internal Imports ============
 import {MerkleLib} from "../libs/Merkle.sol";

--- a/solidity/core/contracts/Outbox.sol
+++ b/solidity/core/contracts/Outbox.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity >=0.8.0;
 
 // ============ Internal Imports ============
 import {Version0} from "./Version0.sol";

--- a/solidity/core/contracts/Outbox.sol
+++ b/solidity/core/contracts/Outbox.sol
@@ -117,7 +117,7 @@ contract Outbox is IOutbox, Version0, MerkleTreeManager, Common {
         // format the message into packed bytes
         bytes memory _message = Message.formatMessage(
             localDomain,
-            msg.sender.toBytes32(),
+            msg.sender.addressToBytes32(),
             _destinationDomain,
             _recipientAddress,
             _messageBody

--- a/solidity/core/contracts/Outbox.sol
+++ b/solidity/core/contracts/Outbox.sol
@@ -6,6 +6,7 @@ import {Version0} from "./Version0.sol";
 import {Common} from "./Common.sol";
 import {MerkleLib} from "../libs/Merkle.sol";
 import {Message} from "../libs/Message.sol";
+import {TypeCasts} from "../libs/TypeCasts.sol";
 import {MerkleTreeManager} from "./Merkle.sol";
 import {IOutbox} from "../interfaces/IOutbox.sol";
 
@@ -23,6 +24,7 @@ contract Outbox is IOutbox, Version0, MerkleTreeManager, Common {
     // ============ Libraries ============
 
     using MerkleLib for MerkleLib.Tree;
+    using TypeCasts for address;
 
     // ============ Constants ============
 
@@ -107,7 +109,7 @@ contract Outbox is IOutbox, Version0, MerkleTreeManager, Common {
     function dispatch(
         uint32 _destinationDomain,
         bytes32 _recipientAddress,
-        bytes memory _messageBody
+        bytes calldata _messageBody
     ) external override notFailed returns (uint256) {
         require(_messageBody.length <= MAX_MESSAGE_BODY_BYTES, "msg too long");
         // The leaf has not been inserted yet at this point1
@@ -115,7 +117,7 @@ contract Outbox is IOutbox, Version0, MerkleTreeManager, Common {
         // format the message into packed bytes
         bytes memory _message = Message.formatMessage(
             localDomain,
-            bytes32(uint256(uint160(msg.sender))),
+            msg.sender.toBytes32(),
             _destinationDomain,
             _recipientAddress,
             _messageBody

--- a/solidity/core/contracts/Version0.sol
+++ b/solidity/core/contracts/Version0.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity >=0.8.0;
 
 /**
  * @title Version0

--- a/solidity/core/contracts/Version0.sol
+++ b/solidity/core/contracts/Version0.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.8.0;
+pragma solidity >=0.6.11;
 
 /**
  * @title Version0

--- a/solidity/core/contracts/test/MysteryMath.sol
+++ b/solidity/core/contracts/test/MysteryMath.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.6.11;
+pragma solidity >=0.8.0;
 
 abstract contract MysteryMath {
     uint256 public stateVar;

--- a/solidity/core/contracts/test/MysteryMathV1.sol
+++ b/solidity/core/contracts/test/MysteryMathV1.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.6.11;
+pragma solidity >=0.8.0;
 
 import "./MysteryMath.sol";
 

--- a/solidity/core/contracts/test/MysteryMathV2.sol
+++ b/solidity/core/contracts/test/MysteryMathV2.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.6.11;
+pragma solidity >=0.8.0;
 
 import "./MysteryMath.sol";
 

--- a/solidity/core/contracts/test/TestCommon.sol
+++ b/solidity/core/contracts/test/TestCommon.sol
@@ -6,7 +6,7 @@ import "../Common.sol";
 contract TestCommon is Common {
     constructor(uint32 _localDomain) Common(_localDomain) {}
 
-    function initialize(address _validatorManager) external {
+    function initialize(address _validatorManager) external initializer {
         __Common_initialize(_validatorManager);
     }
 }

--- a/solidity/core/contracts/test/TestCommon.sol
+++ b/solidity/core/contracts/test/TestCommon.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity >=0.8.0;
 
 import "../Common.sol";
 

--- a/solidity/core/contracts/test/TestInbox.sol
+++ b/solidity/core/contracts/test/TestInbox.sol
@@ -4,9 +4,7 @@ pragma solidity >=0.6.11;
 import "../Inbox.sol";
 
 contract TestInbox is Inbox {
-    using TypedMemView for bytes;
-    using TypedMemView for bytes29;
-    using Message for bytes29;
+    using Message for bytes32;
 
     constructor(uint32 _localDomain) Inbox(_localDomain) {} // solhint-disable-line no-empty-blocks
 
@@ -36,14 +34,12 @@ contract TestInbox is Inbox {
         view
         returns (string memory)
     {
-        bytes29 _view = _res.ref(0);
-
         // If the _res length is less than 68, then the transaction failed
         // silently (without a revert message)
-        if (_view.len() < 68) return "Transaction reverted silently";
+        if (_res.length < 68) return "Transaction reverted silently";
 
         // Remove the selector which is the first 4 bytes
-        bytes memory _revertData = _view.slice(4, _res.length - 4, 0).clone();
+        bytes memory _revertData = _res[4:];
 
         // All that remains is the revert string
         return abi.decode(_revertData, (string));

--- a/solidity/core/contracts/test/TestInbox.sol
+++ b/solidity/core/contracts/test/TestInbox.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity >=0.8.0;
 
 import "../Inbox.sol";
 
@@ -29,19 +29,16 @@ contract TestInbox is Inbox {
         messages[_leaf] = status;
     }
 
-    function getRevertMsg(bytes memory _res)
+    function getRevertMsg(bytes calldata _res)
         internal
-        view
+        pure
         returns (string memory)
     {
         // If the _res length is less than 68, then the transaction failed
         // silently (without a revert message)
         if (_res.length < 68) return "Transaction reverted silently";
 
-        // Remove the selector which is the first 4 bytes
-        bytes memory _revertData = _res[4:];
-
-        // All that remains is the revert string
-        return abi.decode(_revertData, (string));
+        // Remove the selector (first 4 bytes) and decode revert string
+        return abi.decode(_res[4:], (string));
     }
 }

--- a/solidity/core/contracts/test/TestMerkle.sol
+++ b/solidity/core/contracts/test/TestMerkle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity >=0.8.0;
 
 import "../Merkle.sol";
 

--- a/solidity/core/contracts/test/TestMessage.sol
+++ b/solidity/core/contracts/test/TestMessage.sol
@@ -1,47 +1,44 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity >=0.8.0;
 
 import {Message} from "../../libs/Message.sol";
-import {TypedMemView} from "@summa-tx/memview-sol/contracts/TypedMemView.sol";
 
 contract TestMessage {
-    using Message for bytes29;
-    using TypedMemView for bytes;
-    using TypedMemView for bytes29;
+    using Message for bytes;
 
-    function body(bytes memory _message) external view returns (bytes memory) {
-        return _message.ref(0).body().clone();
+    function body(bytes calldata _message) external pure returns (bytes memory) {
+        return _message.body();
     }
 
-    function origin(bytes memory _message) external pure returns (uint32) {
-        return _message.ref(0).origin();
+    function origin(bytes calldata _message) external pure returns (uint32) {
+        return _message.origin();
     }
 
-    function sender(bytes memory _message) external pure returns (bytes32) {
-        return _message.ref(0).sender();
+    function sender(bytes calldata _message) external pure returns (bytes32) {
+        return _message.sender();
     }
 
-    function destination(bytes memory _message) external pure returns (uint32) {
-        return _message.ref(0).destination();
+    function destination(bytes calldata _message) external pure returns (uint32) {
+        return _message.destination();
     }
 
-    function recipient(bytes memory _message) external pure returns (bytes32) {
-        return _message.ref(0).recipient();
+    function recipient(bytes calldata _message) external pure returns (bytes32) {
+        return _message.recipient();
     }
 
-    function recipientAddress(bytes memory _message)
+    function recipientAddress(bytes calldata _message)
         external
         pure
         returns (address)
     {
-        return _message.ref(0).recipientAddress();
+        return _message.recipientAddress();
     }
 
-    function leaf(bytes memory _message, uint256 _leafIndex)
+    function leaf(bytes calldata _message, uint256 _leafIndex)
         external
-        view
+        pure
         returns (bytes32)
     {
-        return _message.ref(0).leaf(_leafIndex);
+        return _message.leaf(_leafIndex);
     }
 }

--- a/solidity/core/contracts/test/TestMessage.sol
+++ b/solidity/core/contracts/test/TestMessage.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.8.0;
+pragma solidity >=0.6.11;
 
 import {Message} from "../../libs/Message.sol";
 
@@ -9,41 +9,49 @@ contract TestMessage {
     function body(bytes calldata _message)
         external
         pure
-        returns (bytes memory)
+        returns (bytes calldata _body)
     {
-        return _message.body();
+        (, , , , _body) = _message.destructure();
     }
 
-    function origin(bytes calldata _message) external pure returns (uint32) {
-        return _message.origin();
+    function origin(bytes calldata _message)
+        external
+        pure
+        returns (uint32 _origin)
+    {
+        (_origin, , , , ) = _message.destructure();
     }
 
-    function sender(bytes calldata _message) external pure returns (bytes32) {
-        return _message.sender();
+    function sender(bytes calldata _message)
+        external
+        pure
+        returns (bytes32 _sender)
+    {
+        (, _sender, , , ) = _message.destructure();
     }
 
     function destination(bytes calldata _message)
         external
         pure
-        returns (uint32)
+        returns (uint32 _destination)
     {
-        return _message.destination();
+        (, , _destination, , ) = _message.destructure();
     }
 
     function recipient(bytes calldata _message)
         external
         pure
-        returns (bytes32)
+        returns (bytes32 _recipient)
     {
-        return _message.recipient();
+        (, , , _recipient, ) = _message.destructure();
     }
 
     function recipientAddress(bytes calldata _message)
         external
         pure
-        returns (address)
+        returns (address _recipient)
     {
-        return _message.recipientAddress();
+        (, , , _recipient, ) = _message.destructureAddresses();
     }
 
     function leaf(bytes calldata _message, uint256 _leafIndex)

--- a/solidity/core/contracts/test/TestMessage.sol
+++ b/solidity/core/contracts/test/TestMessage.sol
@@ -6,7 +6,11 @@ import {Message} from "../../libs/Message.sol";
 contract TestMessage {
     using Message for bytes;
 
-    function body(bytes calldata _message) external pure returns (bytes memory) {
+    function body(bytes calldata _message)
+        external
+        pure
+        returns (bytes memory)
+    {
         return _message.body();
     }
 
@@ -18,11 +22,19 @@ contract TestMessage {
         return _message.sender();
     }
 
-    function destination(bytes calldata _message) external pure returns (uint32) {
+    function destination(bytes calldata _message)
+        external
+        pure
+        returns (uint32)
+    {
         return _message.destination();
     }
 
-    function recipient(bytes calldata _message) external pure returns (bytes32) {
+    function recipient(bytes calldata _message)
+        external
+        pure
+        returns (bytes32)
+    {
         return _message.recipient();
     }
 

--- a/solidity/core/contracts/test/TestMultisigValidatorManager.sol
+++ b/solidity/core/contracts/test/TestMultisigValidatorManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity >=0.8.0;
 pragma abicoder v2;
 
 import {MultisigValidatorManager} from "../validator-manager/MultisigValidatorManager.sol";

--- a/solidity/core/contracts/test/TestOutbox.sol
+++ b/solidity/core/contracts/test/TestOutbox.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity >=0.8.0;
 
 // ============ Internal Imports ============
 import "../Outbox.sol";

--- a/solidity/core/contracts/test/TestRecipient.sol
+++ b/solidity/core/contracts/test/TestRecipient.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity >=0.8.0;
 
 import {IMessageRecipient} from "../../interfaces/IMessageRecipient.sol";
 

--- a/solidity/core/contracts/test/TestRecipient.sol
+++ b/solidity/core/contracts/test/TestRecipient.sol
@@ -14,7 +14,7 @@ contract TestRecipient is IMessageRecipient {
     function handle(
         uint32,
         bytes32,
-        bytes memory
+        bytes calldata
     ) external pure override {} // solhint-disable-line no-empty-blocks
 
     function receiveString(string calldata _str)

--- a/solidity/core/contracts/test/TestValidatorManager.sol
+++ b/solidity/core/contracts/test/TestValidatorManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity >=0.8.0;
 
 import {IInbox} from "../../interfaces/IInbox.sol";
 

--- a/solidity/core/contracts/test/bad-recipient/BadRecipient1.sol
+++ b/solidity/core/contracts/test/bad-recipient/BadRecipient1.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity >=0.8.0;
 
 import {IMessageRecipient} from "../../../interfaces/IMessageRecipient.sol";
 

--- a/solidity/core/contracts/test/bad-recipient/BadRecipient1.sol
+++ b/solidity/core/contracts/test/bad-recipient/BadRecipient1.sol
@@ -7,7 +7,7 @@ contract BadRecipient1 is IMessageRecipient {
     function handle(
         uint32,
         bytes32,
-        bytes memory
+        bytes calldata
     ) external pure override {
         assembly {
             revert(0, 0)

--- a/solidity/core/contracts/test/bad-recipient/BadRecipient3.sol
+++ b/solidity/core/contracts/test/bad-recipient/BadRecipient3.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity >=0.8.0;
 
 import {IMessageRecipient} from "../../../interfaces/IMessageRecipient.sol";
 

--- a/solidity/core/contracts/test/bad-recipient/BadRecipient3.sol
+++ b/solidity/core/contracts/test/bad-recipient/BadRecipient3.sol
@@ -7,7 +7,7 @@ contract BadRecipient3 is IMessageRecipient {
     function handle(
         uint32,
         bytes32,
-        bytes memory
+        bytes calldata
     ) external pure override {
         assembly {
             mstore(0, 0xabcdef)

--- a/solidity/core/contracts/test/bad-recipient/BadRecipient5.sol
+++ b/solidity/core/contracts/test/bad-recipient/BadRecipient5.sol
@@ -7,7 +7,7 @@ contract BadRecipient5 is IMessageRecipient {
     function handle(
         uint32,
         bytes32,
-        bytes memory
+        bytes calldata
     ) external pure override {
         require(false, "no can do");
     }

--- a/solidity/core/contracts/test/bad-recipient/BadRecipient5.sol
+++ b/solidity/core/contracts/test/bad-recipient/BadRecipient5.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity >=0.8.0;
 
 import {IMessageRecipient} from "../../../interfaces/IMessageRecipient.sol";
 

--- a/solidity/core/contracts/test/bad-recipient/BadRecipient6.sol
+++ b/solidity/core/contracts/test/bad-recipient/BadRecipient6.sol
@@ -7,7 +7,7 @@ contract BadRecipient6 is IMessageRecipient {
     function handle(
         uint32,
         bytes32,
-        bytes memory
+        bytes calldata
     ) external pure override {
         require(false); // solhint-disable-line reason-string
     }

--- a/solidity/core/contracts/test/bad-recipient/BadRecipient6.sol
+++ b/solidity/core/contracts/test/bad-recipient/BadRecipient6.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity >=0.8.0;
 
 import {IMessageRecipient} from "../../../interfaces/IMessageRecipient.sol";
 

--- a/solidity/core/contracts/test/bad-recipient/BadRecipientHandle.sol
+++ b/solidity/core/contracts/test/bad-recipient/BadRecipientHandle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity >=0.8.0;
 
 contract BadRecipientHandle {
     function handle(uint32, bytes32) external pure {} // solhint-disable-line no-empty-blocks

--- a/solidity/core/contracts/test/bad-recipient/RandomBadRecipient.sol
+++ b/solidity/core/contracts/test/bad-recipient/RandomBadRecipient.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity >=0.8.0;
 
 import {IMessageRecipient} from "../../../interfaces/IMessageRecipient.sol";
 

--- a/solidity/core/contracts/test/bad-recipient/RandomBadRecipient.sol
+++ b/solidity/core/contracts/test/bad-recipient/RandomBadRecipient.sol
@@ -9,7 +9,7 @@ contract BadRandomRecipient is IMessageRecipient {
     function handle(
         uint32,
         bytes32,
-        bytes memory
+        bytes calldata
     ) external override {
         bool isBlockHashEven = uint256(blockhash(block.number - 1)) % 2 == 0;
         require(isBlockHashEven, "block hash is odd");

--- a/solidity/core/contracts/upgrade/UpgradeBeacon.sol
+++ b/solidity/core/contracts/upgrade/UpgradeBeacon.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.6.11;
+pragma solidity >=0.8.0;
 
 // ============ External Imports ============
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";

--- a/solidity/core/contracts/upgrade/UpgradeBeaconController.sol
+++ b/solidity/core/contracts/upgrade/UpgradeBeaconController.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity >=0.8.0;
 
 // ============ Internal Imports ============
 import {UpgradeBeacon} from "./UpgradeBeacon.sol";

--- a/solidity/core/contracts/upgrade/UpgradeBeaconProxy.sol
+++ b/solidity/core/contracts/upgrade/UpgradeBeaconProxy.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.6.11;
+pragma solidity >=0.8.0;
 
 // ============ External Imports ============
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";

--- a/solidity/core/contracts/validator-manager/InboxValidatorManager.sol
+++ b/solidity/core/contracts/validator-manager/InboxValidatorManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity >=0.8.0;
 pragma abicoder v2;
 
 // ============ Internal Imports ============

--- a/solidity/core/contracts/validator-manager/MultisigValidatorManager.sol
+++ b/solidity/core/contracts/validator-manager/MultisigValidatorManager.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity >=0.8.0;
 pragma abicoder v2;
 
 // ============ External Imports ============
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
-import {ECDSA} from "@openzeppelin/contracts/cryptography/ECDSA.sol";
-import {EnumerableSet} from "@openzeppelin/contracts/utils/EnumerableSet.sol";
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
 /**
  * @title MultisigValidatorManager

--- a/solidity/core/contracts/validator-manager/OutboxValidatorManager.sol
+++ b/solidity/core/contracts/validator-manager/OutboxValidatorManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity >=0.8.0;
 pragma abicoder v2;
 
 // ============ Internal Imports ============

--- a/solidity/core/hardhat.config.ts
+++ b/solidity/core/hardhat.config.ts
@@ -9,7 +9,7 @@ import "hardhat-gas-reporter";
  */
 module.exports = {
   solidity: {
-    version: "0.7.6",
+    version: '0.8.13',
     settings: {
       optimizer: {
         enabled: true,

--- a/solidity/core/interfaces/IMessageRecipient.sol
+++ b/solidity/core/interfaces/IMessageRecipient.sol
@@ -5,6 +5,6 @@ interface IMessageRecipient {
     function handle(
         uint32 _origin,
         bytes32 _sender,
-        bytes memory _message
+        bytes calldata _message
     ) external;
 }

--- a/solidity/core/libs/Message.sol
+++ b/solidity/core/libs/Message.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-pragma solidity >=0.6.11;
+pragma solidity >=0.8.0;
 
 import {TypeCasts} from "./TypeCasts.sol";
 

--- a/solidity/core/libs/Message.sol
+++ b/solidity/core/libs/Message.sol
@@ -117,9 +117,9 @@ library Message {
         ) = destructure(_message);
         return (
             _origin,
-            _sender.toAddress(),
+            _sender.bytes32ToAddress(),
             destination,
-            _recipient.toAddress(),
+            _recipient.bytes32ToAddress(),
             body
         );
     }

--- a/solidity/core/libs/Message.sol
+++ b/solidity/core/libs/Message.sol
@@ -40,35 +40,11 @@ library Message {
 
     /**
      * @notice Returns leaf of formatted message with provided fields.
-     * @param _origin Domain of home chain
-     * @param _sender Address of sender as bytes32
-     * @param _destination Domain of destination chain
-     * @param _recipient Address of recipient on destination chain as bytes32
-     * @param _body Raw bytes of message body
+     * @dev hash of abi packed message and leaf index.
+     * @param _message Raw bytes of message contents.
      * @param _leafIndex Index of the message in the tree
      * @return Leaf (hash) of formatted message
-     **/
-    function messageHash(
-        uint32 _origin,
-        bytes32 _sender,
-        uint32 _destination,
-        bytes32 _recipient,
-        bytes calldata _body,
-        uint256 _leafIndex
-    ) internal pure returns (bytes32) {
-        return
-            keccak256(
-                abi.encodePacked(
-                    _origin,
-                    _sender,
-                    _destination,
-                    _recipient,
-                    _body,
-                    _leafIndex
-                )
-            );
-    }
-
+     */
     function leaf(bytes calldata _message, uint256 _leafIndex)
         internal
         pure
@@ -77,6 +53,16 @@ library Message {
         return keccak256(abi.encodePacked(_message, _leafIndex));
     }
 
+    /**
+     * @notice Decode raw message bytes into structured message fields.
+     * @dev Efficiently slices calldata into structured message fields.
+     * @param _message Raw bytes of message contents.
+     * @return origin Domain of home chain
+     * @return sender Address of sender as bytes32
+     * @return destination Domain of destination chain
+     * @return recipient Address of recipient on destination chain as bytes32
+     * @return body Raw bytes of message body
+     */
     function destructure(bytes calldata _message)
         internal
         pure
@@ -97,6 +83,16 @@ library Message {
         );
     }
 
+    /**
+     * @notice Decode raw message bytes into structured message fields.
+     * @dev Efficiently slices calldata into structured message fields.
+     * @param _message Raw bytes of message contents.
+     * @return origin Domain of home chain
+     * @return sender Address of sender as address (bytes20)
+     * @return destination Domain of destination chain
+     * @return recipient Address of recipient on destination chain as address (bytes20)
+     * @return body Raw bytes of message body
+     */
     function destructureAddresses(bytes calldata _message)
         internal
         pure

--- a/solidity/core/libs/TypeCasts.sol
+++ b/solidity/core/libs/TypeCasts.sol
@@ -1,20 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.6.11;
 
-import "@summa-tx/memview-sol/contracts/TypedMemView.sol";
-
 library TypeCasts {
-    using TypedMemView for bytes;
-    using TypedMemView for bytes29;
-
-    function coerceBytes32(string memory _s)
-        internal
-        pure
-        returns (bytes32 _b)
-    {
-        _b = bytes(_s).ref(0).index(0, uint8(bytes(_s).length));
-    }
-
     // treat it as a null-terminated string of max 32 bytes
     function coerceString(bytes32 _buf)
         internal

--- a/solidity/core/libs/TypeCasts.sol
+++ b/solidity/core/libs/TypeCasts.sol
@@ -23,12 +23,12 @@ library TypeCasts {
     }
 
     // alignment preserving cast
-    function addressToBytes32(address _addr) internal pure returns (bytes32) {
+    function toBytes32(address _addr) internal pure returns (bytes32) {
         return bytes32(uint256(uint160(_addr)));
     }
 
     // alignment preserving cast
-    function bytes32ToAddress(bytes32 _buf) internal pure returns (address) {
+    function toAddress(bytes32 _buf) internal pure returns (address) {
         return address(uint160(uint256(_buf)));
     }
 }

--- a/solidity/core/libs/TypeCasts.sol
+++ b/solidity/core/libs/TypeCasts.sol
@@ -23,12 +23,12 @@ library TypeCasts {
     }
 
     // alignment preserving cast
-    function toBytes32(address _addr) internal pure returns (bytes32) {
+    function addressToBytes32(address _addr) internal pure returns (bytes32) {
         return bytes32(uint256(uint160(_addr)));
     }
 
     // alignment preserving cast
-    function toAddress(bytes32 _buf) internal pure returns (address) {
+    function bytes32ToAddress(bytes32 _buf) internal pure returns (address) {
         return address(uint160(uint256(_buf)));
     }
 }

--- a/solidity/core/package.json
+++ b/solidity/core/package.json
@@ -17,7 +17,8 @@
     "solhint-plugin-prettier": "^0.0.5",
     "solidity-coverage": "^0.7.14",
     "ts-node": "^10.1.0",
-    "typechain": "^5.0.0"
+    "typechain": "^5.0.0",
+    "typescript": "^4.3.5"
   },
   "version": "0.1.1",
   "main": "dist/index.js",

--- a/solidity/core/package.json
+++ b/solidity/core/package.json
@@ -35,8 +35,8 @@
   "license": "MIT OR Apache-2.0",
   "dependencies": {
     "@abacus-network/utils": "^0.1.1",
-    "@openzeppelin/contracts": "^3.4.2",
-    "@openzeppelin/contracts-upgradeable": "~3.4.2",
+    "@openzeppelin/contracts": "^4.6.0",
+    "@openzeppelin/contracts-upgradeable": "^4.6.0",
     "@summa-tx/memview-sol": "^2.0.0",
     "ts-generator": "^0.1.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -93,6 +93,7 @@ __metadata:
     ts-generator: ^0.1.1
     ts-node: ^10.1.0
     typechain: ^5.0.0
+    typescript: ^4.3.5
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -74,8 +74,8 @@ __metadata:
     "@abacus-network/utils": ^0.1.1
     "@nomiclabs/hardhat-ethers": ^2.0.1
     "@nomiclabs/hardhat-waffle": ^2.0.1
-    "@openzeppelin/contracts": ^3.4.2
-    "@openzeppelin/contracts-upgradeable": ~3.4.2
+    "@openzeppelin/contracts": ^4.6.0
+    "@openzeppelin/contracts-upgradeable": ^4.6.0
     "@summa-tx/memview-sol": ^2.0.0
     "@typechain/ethers-v5": ~7.0.0
     "@typechain/hardhat": ^2.0.1
@@ -3064,6 +3064,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@openzeppelin/contracts-upgradeable@npm:^4.6.0":
+  version: 4.6.0
+  resolution: "@openzeppelin/contracts-upgradeable@npm:4.6.0"
+  checksum: f9802c9cccf31bd475412ba5d862ed15eed5352302c30b29c38f84aed2dcfe0d957687935a72068f3d44292a4a55b0ff26cd018b2e14a47f16f74f087009aa29
+  languageName: node
+  linkType: hard
+
 "@openzeppelin/contracts-upgradeable@npm:~3.4.2":
   version: 3.4.2
   resolution: "@openzeppelin/contracts-upgradeable@npm:3.4.2"
@@ -3071,7 +3078,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openzeppelin/contracts@npm:^3.4.2, @openzeppelin/contracts@npm:~3.4.2":
+"@openzeppelin/contracts@npm:^4.6.0":
+  version: 4.6.0
+  resolution: "@openzeppelin/contracts@npm:4.6.0"
+  checksum: 1de06211b279d7aef2bb9abbdd58eb80c71256f7e888a10855ea23bb06ef8723b22fb550d06af60247dfbd7f0f23de9821732012d7541a823339070a8442d1db
+  languageName: node
+  linkType: hard
+
+"@openzeppelin/contracts@npm:~3.4.2":
   version: 3.4.2
   resolution: "@openzeppelin/contracts@npm:3.4.2"
   checksum: 0c90f029fe50a49643588e4c8670dae3bbf31795133a6ddce9bdcbc258486332700bb732287baabf7bf807f39182fe8ea2ffa19aa5caf359b1b9c0f083280748


### PR DESCRIPTION
Fixes #378

Needs `solidity >= 0.8` for explicit type conversion from `bytes calldata slice` to `bytesX`

driveby: fixes yarn caching issues where nested (unhoisted) `node_modules` were not handled properly
https://dev.to/mpocock1/how-to-cache-nodemodules-in-github-actions-with-yarn-24eh