### PR TITLE
Make TransactionConfig.overrides optional

### DIFF
--- a/typescript/deploy/src/config.ts
+++ b/typescript/deploy/src/config.ts
@@ -11,7 +11,7 @@ export interface CheckerViolation {
 }
 
 export type TransactionConfig = {
-  overrides: ethers.Overrides;
+  overrides?: ethers.Overrides;
   supports1559?: boolean;
   // The number of confirmations considered reorg safe
   confirmations?: number;

--- a/typescript/deploy/src/utils.ts
+++ b/typescript/deploy/src/utils.ts
@@ -37,15 +37,15 @@ export function getRouterConfig<N extends ChainName>(
 function fixOverrides(config: TransactionConfig): ethers.Overrides {
   if (config.supports1559) {
     return {
-      maxFeePerGas: config.overrides.maxFeePerGas,
-      maxPriorityFeePerGas: config.overrides.maxPriorityFeePerGas,
-      gasLimit: config.overrides.gasLimit,
+      maxFeePerGas: config.overrides?.maxFeePerGas,
+      maxPriorityFeePerGas: config.overrides?.maxPriorityFeePerGas,
+      gasLimit: config.overrides?.gasLimit,
     };
   } else {
     return {
       type: 0,
-      gasPrice: config.overrides.gasPrice,
-      gasLimit: config.overrides.gasLimit,
+      gasPrice: config.overrides?.gasPrice,
+      gasLimit: config.overrides?.gasLimit,
     };
   }
 }


### PR DESCRIPTION
There is no need to require the overrides key to be set, similar to `IDomainConnection`