### PR TITLE
Track starting blocks for Core deployments

### DIFF
--- a/typescript/infra/scripts/core.ts
+++ b/typescript/infra/scripts/core.ts
@@ -12,10 +12,7 @@ async function main() {
   const environment = await getEnvironment();
   const config = getCoreEnvironmentConfig(environment) as any;
   const multiProvider = await config.getMultiProvider();
-  const deployer = new AbacusCoreDeployer(
-    multiProvider,
-    config.core,
-  );
+  const deployer = new AbacusCoreDeployer(multiProvider, config.core);
 
   const addresses = await deployer.deploy();
 

--- a/typescript/infra/scripts/core.ts
+++ b/typescript/infra/scripts/core.ts
@@ -14,7 +14,7 @@ async function main() {
   const multiProvider = await config.getMultiProvider();
   const deployer = new AbacusCoreDeployer(
     multiProvider,
-    config.core.validatorManagers,
+    config.core,
   );
 
   const addresses = await deployer.deploy();

--- a/typescript/infra/src/config/agent.ts
+++ b/typescript/infra/src/config/agent.ts
@@ -243,6 +243,7 @@ export type InboxAddresses = {
 
 export type RustConfig<Networks extends ChainName> = {
   environment: DeployEnvironment;
+  index?: { from: string };
   signers: Partial<ChainMap<Networks, RustSigner>>;
   inboxes: RemoteChainMap<Networks, any, RustContractBlock<InboxAddresses>>;
   outbox: RustContractBlock<OutboxAddresses>;

--- a/typescript/infra/src/core/deploy.ts
+++ b/typescript/infra/src/core/deploy.ts
@@ -41,7 +41,6 @@ export class AbacusCoreDeployer<
   CoreConfig,
   CoreContractAddresses<Networks, any>
 > {
-
   // Tracks the block number per network from which contract deployment started
   startingBlockNumbers: ChainMap<Networks, number | undefined>;
 
@@ -49,8 +48,8 @@ export class AbacusCoreDeployer<
     multiProvider: MultiProvider<Networks>,
     configMap: ChainMap<Networks, CoreConfig>,
   ) {
-    super(multiProvider, configMap)
-    this.startingBlockNumbers = objMap(configMap, () => undefined)
+    super(multiProvider, configMap);
+    this.startingBlockNumbers = objMap(configMap, () => undefined);
   }
 
   async deployContracts<Local extends Networks>(
@@ -62,7 +61,7 @@ export class AbacusCoreDeployer<
     const signer = dc.signer!;
 
     const startingBlockNumber = await provider.getBlockNumber();
-    this.startingBlockNumbers[network] = startingBlockNumber
+    this.startingBlockNumbers[network] = startingBlockNumber;
 
     const upgradeBeaconController = await this.deployContract(
       network,
@@ -241,7 +240,7 @@ export class AbacusCoreDeployer<
       const startingBlockNumber = this.startingBlockNumbers[network];
 
       if (startingBlockNumber) {
-        rustConfig.index = { from: startingBlockNumber.toString() }
+        rustConfig.index = { from: startingBlockNumber.toString() };
       }
 
       this.multiProvider.remotes(network).forEach((remote) => {


### PR DESCRIPTION
Fixes #393 

The agents can be configured to not start from genesis when indexing. This PR tracks the block number at the start of the deployment and then records it in the rust config files