### PR TITLE
Strongly type InterchainGasCalculator

### DIFF
--- a/typescript/sdk/CHANGELOG.md
+++ b/typescript/sdk/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## Unreleased
+
+- [Strongly type InterchainGasCalculator](https://github.com/abacus-network/abacus-monorepo/pull/433): Adds type guards and uses chainNames instead of domain IDs in `InterchainGasCalculator`
+
+## 0.1.1
+
+Initial Alpha Release of the SDK

--- a/typescript/sdk/README.md
+++ b/typescript/sdk/README.md
@@ -1,50 +1,5 @@
-## Abacus SDK
+# Abacus Application SDK
 
-Abacus SDK is a management system for
-[ethers.js](https://docs.ethers.io/v5/) providers and signers that helps
-developers connect to multiple networks simultaneously. It is part
-of the [Abacus](https://github.com/celo-org/optics-monorepo) project, but may
-be useful to other multi-chain systems.
+The Abacus Application SDK help developers manage multichain Abacus applications. This requires a higher level API than dApp developers are familiar with which is namespaced by target chain.
 
-This package includes the `MultiProvider`, as well as an `AbacusContext` for
-interacting with deployed Abacus systems. The dev, staging, and mainnet Abacus
-systems have pre-built objects for quick development.
-
-### Intended Usage
-
-```ts
-import * as ethers from 'ethers';
-
-import { mainnet } from '@abacus-network/sdk';
-
-// Set up providers and signers
-const someEthersProvider = ethers.providers.WsProvider('...');
-const someEthersSigner = new AnySigner(...);
-mainnet.registerProvider('ethereum', someEthersProvider);
-mainnet.registerSigner('ethereum', someEthersSigner);
-
-// We have shortcuts for common provider/signer types
-mainnet.registerRpcProvider('celo', 'https://forno.celo.org');
-mainnet.registerWalletSigner('celo', '0xabcd...');
-
-// Interact with the Abacus Bridge
-// Send ETH from ethereum to celo
-await mainnet.sendNative(
-    'ethereum', // source
-    'celo',  // destination
-    ethers.constants.WeiPerEther, // amount
-    '0x1234...',  // recipient
-);
-
-// Send Tokens from celo to ethereum
-await mainnet.send(
-    'celo',  // source
-    'ethereum', // destination
-    { domain: 'ethereum', id: "0xabcd..."} // token information
-    ethers.constants.WeiPerEther, // amount
-    '0x1234...'  // recipient
-    { gasLimit: 300_000 } // standard ethers tx overrides
-);
-
-// so easy.
-```
+You can find the docs at https://docs.useabacus.network/abacus-docs/developers/application-sdk

--- a/typescript/sdk/src/core/contracts.ts
+++ b/typescript/sdk/src/core/contracts.ts
@@ -45,14 +45,17 @@ export type InboxContracts = {
   validatorManager: InboxValidatorManager;
 };
 
-export type CoreContractSchema<N extends ChainName, L extends N> = {
+export type CoreContractSchema<
+  Networks extends ChainName,
+  Local extends Networks,
+> = {
   abacusConnectionManager: AbacusConnectionManager;
   upgradeBeaconController: UpgradeBeaconController;
   outbox: {
     outbox: Outbox;
     validatorManager: OutboxValidatorManager;
   };
-  inboxes: RemoteChainMap<N, L, InboxContracts>;
+  inboxes: RemoteChainMap<Networks, Local, InboxContracts>;
   interchainGasPaymaster: InterchainGasPaymaster;
 };
 

--- a/typescript/sdk/src/core/index.ts
+++ b/typescript/sdk/src/core/index.ts
@@ -16,7 +16,6 @@ export {
   AbacusMessage,
   AbacusStatus,
   MessageStatus,
-  ParsedMessage,
   parseMessage,
   resolveDomain,
   resolveId,

--- a/typescript/sdk/src/core/message.ts
+++ b/typescript/sdk/src/core/message.ts
@@ -29,6 +29,7 @@ import {
   ProcessTypes,
 } from './events';
 
+// I didn't want to override the existing ParsedMessage in message.ts as that would include having to type AbacusMessage and more and it's not clear to me that we will keep those.
 type ParsedMessage = {
   origin: number;
   sender: string;

--- a/typescript/sdk/src/core/message.ts
+++ b/typescript/sdk/src/core/message.ts
@@ -29,7 +29,7 @@ import {
   ProcessTypes,
 } from './events';
 
-export type ParsedMessage = {
+type ParsedMessage = {
   origin: number;
   sender: string;
   destination: number;

--- a/typescript/sdk/src/gas/calculator.ts
+++ b/typescript/sdk/src/gas/calculator.ts
@@ -1,14 +1,10 @@
-import {
-  AbacusCore,
-  MultiProvider,
-  ParsedMessage,
-  domains,
-  resolveDomain,
-  resolveNetworks,
-} from '..';
+import { AbacusCore, MultiProvider, domains } from '..';
 import { BigNumber, FixedNumber, ethers } from 'ethers';
 
 import { utils } from '@abacus-network/utils';
+
+import { InboxContracts } from '../core/contracts';
+import { ChainName, RemoteChainMap, Remotes } from '../types';
 
 import { DefaultTokenPriceGetter, TokenPriceGetter } from './token-prices';
 import { convertDecimalValue, mulBigAndFixed } from './utils';
@@ -77,12 +73,23 @@ export interface InterchainGasCalculatorConfig {
   tokenPriceGetter?: TokenPriceGetter;
 }
 
+export type ParsedMessage<
+  Networks extends ChainName,
+  Destination extends Networks,
+> = {
+  origin: Exclude<Networks, Destination>;
+  sender: string;
+  destination: Destination;
+  recipient: string;
+  body: string;
+};
+
 /**
  * Calculates interchain gas payments.
  */
-export class InterchainGasCalculator {
-  core: AbacusCore;
-  multiProvider: MultiProvider;
+export class InterchainGasCalculator<Networks extends ChainName> {
+  core: AbacusCore<Networks>;
+  multiProvider: MultiProvider<Networks>;
 
   tokenPriceGetter: TokenPriceGetter;
 
@@ -90,8 +97,8 @@ export class InterchainGasCalculator {
   messageGasEstimateBuffer: ethers.BigNumber;
 
   constructor(
-    multiProvider: MultiProvider,
-    core: AbacusCore,
+    multiProvider: MultiProvider<Networks>,
+    core: AbacusCore<Networks>,
     config?: InterchainGasCalculatorConfig,
   ) {
     this.multiProvider = multiProvider;
@@ -116,23 +123,23 @@ export class InterchainGasCalculator {
    * the destination chain, gas costs incurred by a relayer when submitting a signed
    * checkpoint to the destination chain, and the overhead gas cost in Inbox of processing
    * a message. Applies the multiplier `paymentEstimateMultiplier`.
-   * @param originDomain The domain of the origin chain.
-   * @param destinationDomain The domain of the destination chain.
+   * @param origin The name of the origin chain.
+   * @param destination The name of the destination chain.
    * @param destinationHandleGas The amount of gas the recipient `handle` function
    * is estimated to use.
    * @returns An estimated amount of origin chain tokens to cover gas costs of the
    * message on the destination chain.
    */
-  async estimatePaymentForHandleGasAmount(
-    originDomain: number,
-    destinationDomain: number,
+  async estimatePaymentForHandleGasAmount<Destination extends Networks>(
+    origin: Exclude<Networks, Destination>,
+    destination: Destination,
     destinationHandleGas: BigNumber,
   ): Promise<BigNumber> {
-    const destinationGasPrice = await this.suggestedGasPrice(destinationDomain);
+    const destinationGasPrice = await this.suggestedGasPrice(destination);
 
     const checkpointRelayGas = await this.checkpointRelayGas(
-      originDomain,
-      destinationDomain,
+      origin,
+      destination,
     );
     const inboxProcessOverheadGas = await this.inboxProcessOverheadGas();
     const totalDestinationGas = checkpointRelayGas
@@ -142,8 +149,8 @@ export class InterchainGasCalculator {
 
     // Convert from destination domain native tokens to origin domain native tokens.
     const originCostWei = await this.convertBetweenNativeTokens(
-      destinationDomain,
-      originDomain,
+      destination,
+      origin,
       destinationCostWei,
     );
 
@@ -165,7 +172,9 @@ export class InterchainGasCalculator {
    * @returns An estimated amount of origin chain tokens to cover gas costs of the
    * message on the destination chain.
    */
-  async estimatePaymentForMessage(message: ParsedMessage) {
+  async estimatePaymentForMessage<Destination extends Networks>(
+    message: ParsedMessage<Networks, Destination>,
+  ) {
     const destinationGas = await this.estimateHandleGasForMessage(message);
     return this.estimatePaymentForHandleGasAmount(
       message.origin,
@@ -176,23 +185,23 @@ export class InterchainGasCalculator {
 
   /**
    * Using the exchange rates provided by tokenPriceGetter, returns the amount of
-   * `toDomain` native tokens equivalent in value to the provided `fromAmount` of
-   * `fromDomain` native tokens. Accounts for differences in the decimals of the tokens.
-   * @param fromDomain The domain whose native token is being converted from.
-   * @param toDomain The domain whose native token is being converted into.
-   * @param fromAmount The amount of `fromDomain` native tokens to convert from.
-   * @returns The amount of `toDomain` native tokens whose value is equivalent to
-   * `fromAmount` of `fromDomain` native tokens.
+   * `toChain` native tokens equivalent in value to the provided `fromAmount` of
+   * `fromChain` native tokens. Accounts for differences in the decimals of the tokens.
+   * @param fromChain The domain whose native token is being converted from.
+   * @param toChain The domain whose native token is being converted into.
+   * @param fromAmount The amount of `fromChain` native tokens to convert from.
+   * @returns The amount of `toChain` native tokens whose value is equivalent to
+   * `fromAmount` of `fromChain` native tokens.
    */
   async convertBetweenNativeTokens(
-    fromDomain: number,
-    toDomain: number,
+    fromChain: Networks,
+    toChain: Networks,
     fromAmount: BigNumber,
   ): Promise<BigNumber> {
     // A FixedNumber that doesn't care what the decimals of the from/to
     // tokens are -- it is just the amount of whole from tokens that a single
     // whole to token is equivalent in value to.
-    const exchangeRate = await this.getExchangeRate(toDomain, fromDomain);
+    const exchangeRate = await this.getExchangeRate(toChain, fromChain);
 
     // Apply the exchange rate to the amount. This does not yet account for differences in
     // decimals between the two tokens.
@@ -205,27 +214,27 @@ export class InterchainGasCalculator {
     // Converts exchangeRateProduct to having the correct number of decimals.
     return convertDecimalValue(
       exchangeRateProduct,
-      this.nativeTokenDecimals(fromDomain),
-      this.nativeTokenDecimals(toDomain),
+      this.nativeTokenDecimals(fromChain),
+      this.nativeTokenDecimals(toChain),
     );
   }
 
   /**
-   * @param baseDomain The domain whose native token is the base asset.
-   * @param quoteDomain The domain whose native token is the quote asset.
-   * @returns The exchange rate of the native tokens of the baseDomain and the quoteDomain.
+   * @param baseChain The domain whose native token is the base asset.
+   * @param quoteChain The domain whose native token is the quote asset.
+   * @returns The exchange rate of the native tokens of the baseChain and the quoteChain.
    * I.e. the number of whole quote tokens a single whole base token is equivalent
    * in value to.
    */
   async getExchangeRate(
-    baseDomain: number,
-    quoteDomain: number,
+    baseChain: Networks,
+    quoteChain: Networks,
   ): Promise<FixedNumber> {
     const baseUsd = await this.tokenPriceGetter.getNativeTokenUsdPrice(
-      baseDomain,
+      baseChain,
     );
     const quoteUsd = await this.tokenPriceGetter.getNativeTokenUsdPrice(
-      quoteDomain,
+      quoteChain,
     );
 
     // This operation is called "unsafe" because of the unintuitive rounding that
@@ -240,26 +249,22 @@ export class InterchainGasCalculator {
 
   /**
    * Gets a suggested gas price for a domain.
-   * @param domain The domain of the chain to estimate gas prices for.
+   * @param chainName The name of the chain to get the gas price for
    * @returns The suggested gas price in wei on the destination chain.
    */
-  async suggestedGasPrice(domain: number): Promise<BigNumber> {
-    const provider = this.multiProvider.getDomainConnection(
-      resolveDomain(domain),
-    ).provider!;
+  async suggestedGasPrice(chainName: Networks): Promise<BigNumber> {
+    const provider =
+      this.multiProvider.getDomainConnection(chainName).provider!;
     return provider.getGasPrice();
   }
 
   /**
-   * Gets the number of decimals of the provided domain's native token.
-   * @param domain The domain.
-   * @returns The number of decimals of `domain`'s native token.
+   * Gets the number of decimals of the provided chain's native token.
+   * @param chain The chain.
+   * @returns The number of decimals of `chain`'s native token.
    */
-  nativeTokenDecimals(domain: number) {
-    return (
-      domains[resolveDomain(domain)].nativeTokenDecimals ??
-      DEFAULT_TOKEN_DECIMALS
-    );
+  nativeTokenDecimals(chain: Networks) {
+    return domains[chain].nativeTokenDecimals ?? DEFAULT_TOKEN_DECIMALS;
   }
 
   /**
@@ -276,17 +281,15 @@ export class InterchainGasCalculator {
    * @returns The estimated gas required by the message's recipient handle function
    * on the destination chain.
    */
-  async estimateHandleGasForMessage(
-    message: ParsedMessage,
+  async estimateHandleGasForMessage<Local extends Networks>(
+    message: ParsedMessage<Networks, Local>,
   ): Promise<BigNumber> {
-    const provider = this.multiProvider.getDomainConnection(
-      resolveDomain(message.destination),
-    ).provider!;
+    const provider = this.multiProvider.getDomainConnection(message.destination)
+      .provider!;
 
-    const messageNetworks = resolveNetworks(message);
-    const { inbox } = this.core.getMailboxPair(
-      messageNetworks.origin as never,
-      messageNetworks.destination,
+    const { inbox } = this.core.getMailboxPair<Local>(
+      message.origin,
+      message.destination,
     );
 
     const handlerInterface = new ethers.utils.Interface([
@@ -315,18 +318,18 @@ export class InterchainGasCalculator {
   }
 
   /**
-   * @param originDomain The domain of the origin chain.
-   * @param destinationDomain The domain of the destination chain.
+   * @param origin The name of the origin chain.
+   * @param destination The name of the destination chain.
    * @returns An estimated gas amount a relayer will spend when submitting a signed
    * checkpoint to the destination domain.
    */
-  async checkpointRelayGas(
-    originDomain: number,
-    destinationDomain: number,
+  async checkpointRelayGas<Destination extends Networks>(
+    origin: Remotes<Networks, Destination>,
+    destination: Destination,
   ): Promise<BigNumber> {
-    const inboxValidatorManager = this.core.getContracts(
-      resolveDomain(destinationDomain) as never,
-    ).inboxes[resolveDomain(originDomain)].validatorManager;
+    const inboxes: RemoteChainMap<Networks, Destination, InboxContracts> =
+      this.core.getContracts(destination).inboxes;
+    const inboxValidatorManager = inboxes[origin].validatorManager;
     const threshold = await inboxValidatorManager.threshold();
 
     return threshold

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -20,7 +20,6 @@ export {
   InboxContracts,
   MailboxAddresses,
   MessageStatus,
-  ParsedMessage,
   parseMessage,
   resolveDomain,
   resolveId,

--- a/typescript/sdk/src/types.ts
+++ b/typescript/sdk/src/types.ts
@@ -43,6 +43,8 @@ export type ChainMap<Networks extends ChainName, Value> = Record<
   Value
 >;
 
+export type TestChainNames = 'test1' | 'test2' | 'test3';
+
 export const AllChains = Object.keys(Chains) as ChainName[];
 export const DomainIdToChainName = Object.fromEntries(
   AllChains.map((chain) => [domains[chain].id, chain]),
@@ -56,6 +58,7 @@ export type Remotes<
   Networks extends ChainName,
   Local extends Networks,
 > = Exclude<Networks, Local>;
+
 export type RemoteChainMap<
   Networks extends ChainName,
   Local extends Networks,

--- a/typescript/sdk/test/gas/calculator.test.ts
+++ b/typescript/sdk/test/gas/calculator.test.ts
@@ -9,7 +9,6 @@ import {
   Chains,
   InterchainGasCalculator,
   MultiProvider,
-  resolveDomain,
 } from '../..';
 import { ParsedMessage } from '../../src/gas/calculator';
 import { TestChainNames } from '../../src/types';
@@ -209,6 +208,7 @@ describe('InterchainGasCalculator', () => {
         // of the object so we can stub `threshold`.
         const validatorManager = Object.assign(
           {},
+          // @ts-ignore Typescript has trouble properly typing the stubbed getContracts
           contracts.inboxes[origin].validatorManager,
         );
 
@@ -219,6 +219,7 @@ describe('InterchainGasCalculator', () => {
             .stub(validatorManager, 'threshold')
             .callsFake(() => Promise.resolve(BigNumber.from(threshold)));
 
+          // @ts-ignore Typescript has trouble properly typing the stubbed getContracts
           contracts.inboxes[origin].validatorManager = validatorManager;
         }
         return contracts;

--- a/typescript/sdk/test/utils.ts
+++ b/typescript/sdk/test/utils.ts
@@ -1,7 +1,7 @@
 import { FixedNumber, ethers } from 'ethers';
 
-import { NameOrDomain } from '../src';
-import { resolveId } from '../src/core/message';
+import { ChainName } from '../dist';
+import { ChainMap } from '../src';
 
 const MOCK_NETWORK = {
   name: 'MockNetwork',
@@ -42,23 +42,23 @@ export class MockProvider extends ethers.providers.BaseProvider {
 }
 
 // A mock TokenPriceGetter intended to be used by tests when mocking token prices
-export class MockTokenPriceGetter {
-  private tokenPrices: { [domain: number]: FixedNumber };
+export class MockTokenPriceGetter<Networks extends ChainName> {
+  private tokenPrices: Partial<ChainMap<Networks, FixedNumber>>;
 
   constructor() {
     this.tokenPrices = {};
   }
 
-  getNativeTokenUsdPrice(domain: NameOrDomain): Promise<FixedNumber> {
-    const id = resolveId(domain);
-    const price = this.tokenPrices[id];
+  getNativeTokenUsdPrice(chain: Networks): Promise<FixedNumber> {
+    const price = this.tokenPrices[chain];
     if (price) {
-      return Promise.resolve(price);
+      // TS compiler somehow can't deduce the check above
+      return Promise.resolve(price as FixedNumber);
     }
-    throw Error(`No price for domain ${domain}`);
+    throw Error(`No price for chain ${chain}`);
   }
 
-  setTokenPrice(domain: number, price: string | number) {
-    this.tokenPrices[domain] = FixedNumber.from(price);
+  setTokenPrice(chain: Networks, price: string | number) {
+    this.tokenPrices[chain] = FixedNumber.from(price);
   }
 }

--- a/typescript/sdk/test/utils.ts
+++ b/typescript/sdk/test/utils.ts
@@ -1,7 +1,6 @@
 import { FixedNumber, ethers } from 'ethers';
 
-import { ChainName } from '../dist';
-import { ChainMap } from '../src';
+import { ChainMap, ChainName } from '../src';
 
 const MOCK_NETWORK = {
   name: 'MockNetwork',


### PR DESCRIPTION
This PR strongly types InterchainGasCalculator (as well as a dedicated ParsedMessage). This PR also makes InterchainGasCalculator use chain names instead of domain IDs.

I didn't want to override the existing ParsedMessage as that would include having to type AbacusMessage and more and it's not clear to me that we will keep those.

Drive-by changes:
- Removes the sdk's README and points it to the docs
- Adds a changelog file to track breaking changes for the next time sdk gets published


Fixes #407 