### PR TITLE
Add default chain connection configuration

### DIFF
--- a/typescript/infra/config/networks/testnets.ts
+++ b/typescript/infra/config/networks/testnets.ts
@@ -1,109 +1,25 @@
 import { BigNumber } from 'ethers';
 
 import { TransactionConfig } from '@abacus-network/deploy';
+import { chainConnectionConfigs } from '@abacus-network/sdk';
 import { ChainMap } from '@abacus-network/sdk';
 
-export const alfajores: TransactionConfig = {
-  confirmations: 1,
-  overrides: {},
-};
 
-export const fuji: TransactionConfig = {
-  confirmations: 1,
-  overrides: {},
-};
+const {
+  kovan,
+} = chainConnectionConfigs;
 
-export const goerli: TransactionConfig = {
-  confirmations: 3,
-  overrides: {
-    gasPrice: BigNumber.from(10_000_000_000),
-  },
-};
-
-export const kovan: TransactionConfig = {
-  confirmations: 3,
+export const overriddenKovan: TransactionConfig = {
+  ...kovan,
   overrides: {
     gasPrice: BigNumber.from(10_000_000_000),
     gasLimit: 15_000_000,
   },
 };
 
-export const mumbai: TransactionConfig = {
-  confirmations: 3,
-  overrides: {},
-};
-
-export const rinkarby: TransactionConfig = {
-  confirmations: 2,
-  overrides: {
-    gasPrice: 0,
-    gasLimit: 600_000_000,
-  },
-};
-
-export const rinkeby: TransactionConfig = {
-  confirmations: 3,
-  overrides: {},
-};
-
-export const ropsten: TransactionConfig = {
-  confirmations: 3,
-  overrides: {
-    gasPrice: BigNumber.from(10_000_000_000),
-  },
-};
-
-export const test1: TransactionConfig = {
-  confirmations: 1,
-  overrides: {},
-};
-
-export const test2: TransactionConfig = {
-  confirmations: 1,
-  overrides: {},
-};
-
-export const test3: TransactionConfig = {
-  confirmations: 1,
-  overrides: {},
-};
-
-export const bsctestnet: TransactionConfig = {
-  confirmations: 3,
-  overrides: {},
-};
-
-export const arbitrumrinkeby: TransactionConfig = {
-  confirmations: 3,
-  overrides: {},
-};
-
-export const optimismkovan: TransactionConfig = {
-  confirmations: 3,
-  overrides: {},
-};
-
-export const auroratestnet: TransactionConfig = {
-  confirmations: 3,
-  overrides: {},
-};
-
 const _configs = {
-  alfajores,
-  fuji,
-  goerli,
-  kovan,
-  mumbai,
-  rinkarby,
-  rinkeby,
-  ropsten,
-  test1,
-  test2,
-  test3,
-  bsctestnet,
-  arbitrumrinkeby,
-  optimismkovan,
-  auroratestnet,
+  ...chainConnectionConfigs,
+  kovan: overriddenKovan,
 };
 
 export const configs: ChainMap<keyof typeof _configs, TransactionConfig> =

--- a/typescript/sdk/package.json
+++ b/typescript/sdk/package.json
@@ -32,7 +32,7 @@
     "@abacus-network/utils": "^0.1.1",
     "@ethersproject/bignumber": "^5.5.0",
     "@ethersproject/bytes": "^5.5.0",
-    "celo-ethers-provider": "0.0.0",
+    "celo-ethers-provider": "^0.0.0",
     "ethers": "^5.4.7"
   }
 }

--- a/typescript/sdk/src/chains.ts
+++ b/typescript/sdk/src/chains.ts
@@ -1,0 +1,75 @@
+import { ChainMap, IDomainConnection } from '@abacus-network/sdk';
+import { StaticCeloJsonRpcProvider } from 'celo-ethers-provider';
+import { ethers } from 'ethers';
+import { ChainName } from './types';
+
+
+export const alfajores: IDomainConnection = {
+  provider: new StaticCeloJsonRpcProvider('https://alfajores-forno.celo.org', 44787),
+  confirmations: 1,
+};
+
+export const fuji: IDomainConnection = {
+  provider: new ethers.providers.JsonRpcProvider('https://api.avax-test.network/ext/bc/C/rpc', 43113),
+  confirmations: 1,
+};
+
+export const kovan: IDomainConnection = {
+  provider: new ethers.providers.JsonRpcProvider('https://kovan.poa.network', 42),
+  confirmations: 1,
+};
+
+export const mumbai: IDomainConnection = {
+  provider: new ethers.providers.JsonRpcProvider('https://rpc-mumbai.maticvigil.com', 80001),
+  confirmations: 30,
+};
+
+export const bsctestnet: IDomainConnection = {
+  provider: new ethers.providers.JsonRpcProvider('https://data-seed-prebsc-1-s3.binance.org:8545', 97),
+  confirmations: 1,
+};
+
+export const arbitrumrinkeby: IDomainConnection = {
+  provider: new ethers.providers.JsonRpcProvider('https://rinkeby.arbitrum.io/rpc', 421611),
+  confirmations: 1,
+};
+
+export const optimismkovan: IDomainConnection = {
+  provider: new ethers.providers.JsonRpcProvider('https://kovan.optimism.io', 69),
+  confirmations: 1,
+};
+
+export const test1: IDomainConnection = {
+  provider: new ethers.providers.JsonRpcProvider('http://localhost:8545', 31337),
+  confirmations: 1,
+};
+
+export const test2: IDomainConnection = {
+  provider: new ethers.providers.JsonRpcProvider('http://localhost:8545', 31337),
+  confirmations: 1,
+};
+
+export const test3: IDomainConnection = {
+  provider: new ethers.providers.JsonRpcProvider('http://localhost:8545', 31337),
+  confirmations: 1,
+};
+
+const _configs = {
+  alfajores,
+  fuji,
+  kovan,
+  mumbai,
+  bsctestnet,
+  arbitrumrinkeby,
+  optimismkovan,
+  test1,
+  test2,
+  test3,
+};
+
+export const addSignerToConnection = <Networks extends ChainName>(signer: ethers.Signer) => (_chain: Networks, connection: IDomainConnection) => ({ ...connection, signer })
+
+export const chainConnectionConfigs: ChainMap<
+  keyof typeof _configs,
+  IDomainConnection
+> = _configs;

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -61,3 +61,4 @@ export {
   Remotes,
 } from './types';
 export { utils, objMap, objMapEntries, promiseObjAll } from './utils';
+export { chainConnectionConfigs, addSignerToConnection } from './chains'


### PR DESCRIPTION
This PR adds a chainmap of default `IDomainConnections` for supported networks which allow the instantiation of a default MultiProvider with minimal input for the developer:

```typescript
import { chainConnectionConfigs, addSignerToConnection } from './chains'

const { alfajores, kovan } = chainConnectionConfigs
const signer = new ethers.Wallet('')
new MultiProvider(objMap({ alfajores, kovan }, addSignerToConnection(signer)))
```