### PR TITLE
Add back initializing guard to Common initializer

### DIFF
--- a/solidity/core/contracts/Common.sol
+++ b/solidity/core/contracts/Common.sol
@@ -68,7 +68,10 @@ abstract contract Common is ICommon, OwnableUpgradeable {
 
     // ============ Initializer ============
 
-    function __Common_initialize(address _validatorManager) internal onlyInitializing {
+    function __Common_initialize(address _validatorManager)
+        internal
+        onlyInitializing
+    {
         // initialize owner
         __Ownable_init();
         _setValidatorManager(_validatorManager);

--- a/solidity/core/contracts/Common.sol
+++ b/solidity/core/contracts/Common.sol
@@ -68,7 +68,7 @@ abstract contract Common is ICommon, OwnableUpgradeable {
 
     // ============ Initializer ============
 
-    function __Common_initialize(address _validatorManager) internal {
+    function __Common_initialize(address _validatorManager) internal onlyInitializing {
         // initialize owner
         __Ownable_init();
         _setValidatorManager(_validatorManager);


### PR DESCRIPTION
Resolves https://github.com/abacus-network/abacus-monorepo/pull/415#discussion_r870229408
Enforces that `Inbox.initialize` and `Outbox.initialize` functions have `initializer` modifiers