### PR TITLE
Fix infra core deployment in test environment

### DIFF
--- a/typescript/deploy/src/config.ts
+++ b/typescript/deploy/src/config.ts
@@ -16,6 +16,7 @@ export type TransactionConfig = {
   // The number of confirmations considered reorg safe
   confirmations?: number;
   signer?: ethers.Signer;
+  provider?: ethers.providers.Provider;
 };
 
 export type EnvironmentConfig<Chain extends ChainName> = ChainMap<

--- a/typescript/infra/config/environments/test/index.ts
+++ b/typescript/infra/config/environments/test/index.ts
@@ -1,3 +1,5 @@
+import { JsonRpcProvider } from '@ethersproject/providers';
+
 import { utils } from '@abacus-network/deploy';
 
 import { CoreEnvironmentConfig } from '../../../src/config';
@@ -16,9 +18,8 @@ export const environment: CoreEnvironmentConfig<TestChains> = {
   infra,
   // NOTE: Does not work from hardhat.config.ts
   getMultiProvider: async () => {
-    const hre = await import('hardhat');
-    await import('@nomiclabs/hardhat-ethers');
-    const [signer] = await hre.ethers.getSigners();
+    const provider = testConfigs.test1.provider! as JsonRpcProvider;
+    const signer = provider.getSigner(0);
     return utils.getMultiProviderFromConfigAndSigner(testConfigs, signer);
   },
 };

--- a/typescript/infra/hardhat.config.ts
+++ b/typescript/infra/hardhat.config.ts
@@ -12,13 +12,7 @@ import {
 } from '@abacus-network/sdk';
 import { utils } from '@abacus-network/utils';
 
-import {
-  getCoreContractsSdkFilepath,
-  getCoreEnvironmentConfig,
-  getCoreRustDirectory,
-  getCoreVerificationDirectory,
-} from './scripts/utils';
-import { AbacusCoreInfraDeployer } from './src/core/deploy';
+import { getCoreEnvironmentConfig } from './scripts/utils';
 import { sleep } from './src/utils/utils';
 import { AbacusContractVerifier } from './src/verify';
 
@@ -61,37 +55,6 @@ const chainSummary = async <Chain extends ChainName>(
   };
   return summary;
 };
-
-task('abacus', 'Deploys abacus on top of an already running Hardhat Network')
-  // If we import ethers from hardhat, we get error HH9 with included note.
-  // You probably tried to import the "hardhat" module from your config or a file imported from it.
-  // This is not possible, as Hardhat can't be initialized while its config is being defined.
-  .setAction(async (_: any, hre: HardhatRuntimeEnvironment) => {
-    const environment = 'test';
-    const config = getCoreEnvironmentConfig(environment);
-
-    // TODO: replace with config.getMultiProvider()
-    const [signer] = await hre.ethers.getSigners();
-    const multiProvider = deployUtils.getMultiProviderFromConfigAndSigner(
-      config.transactionConfigs,
-      signer,
-    );
-
-    const deployer = new AbacusCoreInfraDeployer(multiProvider, config.core);
-    const addresses = await deployer.deploy();
-
-    // Write configs
-    deployer.writeVerification(getCoreVerificationDirectory(environment));
-    deployer.writeRustConfigs(
-      environment,
-      getCoreRustDirectory(environment),
-      addresses,
-    );
-    deployer.writeContracts(
-      addresses,
-      getCoreContractsSdkFilepath(environment),
-    );
-  });
 
 task('kathy', 'Dispatches random abacus messages').setAction(
   async (_, hre: HardhatRuntimeEnvironment) => {

--- a/typescript/infra/package.json
+++ b/typescript/infra/package.json
@@ -20,7 +20,7 @@
     "test": "hardhat test",
     "check": "tsc --noEmit",
     "node": "hardhat node",
-    "abacus": "hardhat abacus --network localhost",
+    "abacus": "ts-node scripts/core.ts -e test",
     "kathy": "hardhat kathy --network localhost",
     "prettier": "prettier --write *.ts ./src ./config ./scripts ./test"
   },

--- a/typescript/infra/scripts/core.ts
+++ b/typescript/infra/scripts/core.ts
@@ -12,10 +12,7 @@ async function main() {
   const environment = await getEnvironment();
   const config = getCoreEnvironmentConfig(environment) as any;
   const multiProvider = await config.getMultiProvider();
-  const deployer = new AbacusCoreInfraDeployer(
-    multiProvider,
-    config.core.validatorManagers,
-  );
+  const deployer = new AbacusCoreInfraDeployer(multiProvider, config.core);
 
   const addresses = await deployer.deploy();
 


### PR DESCRIPTION
This PR makes the deployment scripts in the infra package usable again for the test environment by fixing the multiprovider that gets returned (the signers provider was otherwise a different HRE than the locally running one). This also means that the existing task `yarn hardhat abacus` no longer needs to be invoked via hardhat, but can just be called like any other environment (i.e. `yarn ts-node scripts/core.ts -e test`)

