### PR TITLE
Add prettier precommit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+yarn prettier

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "@abacus-network/monorepo",
   "scripts": {
     "build": "yarn workspaces foreach --parallel --topological run build",
-    "prettier": "yarn workspaces foreach --parallel run prettier"
+    "prettier": "yarn workspaces foreach --parallel run prettier",
+    "postinstall": "husky install"
   },
   "workspaces": [
     "solidity/*",
@@ -13,6 +14,7 @@
   "packageManager": "yarn@3.2.0",
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^3.2.0",
+    "husky": "^8.0.0",
     "prettier": "^2.2.1",
     "typescript": "^4.3.5"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -176,6 +176,7 @@ __metadata:
   resolution: "@abacus-network/monorepo@workspace:."
   dependencies:
     "@trivago/prettier-plugin-sort-imports": ^3.2.0
+    husky: ^8.0.0
     prettier: ^2.2.1
     typescript: ^4.3.5
   languageName: unknown
@@ -9227,6 +9228,15 @@ __metadata:
   dependencies:
     ms: ^2.0.0
   checksum: 9c7a74a2827f9294c009266c82031030eae811ca87b0da3dceb8d6071b9bde22c9f3daef0469c3c533cc67a97d8a167cd9fc0389350e5f415f61a79b171ded16
+  languageName: node
+  linkType: hard
+
+"husky@npm:^8.0.0":
+  version: 8.0.1
+  resolution: "husky@npm:8.0.1"
+  bin:
+    husky: lib/bin.js
+  checksum: 943a73a13d0201318fd30e83d299bb81d866bd245b69e6277804c3b462638dc1921694cb94c2b8c920a4a187060f7d6058d3365152865406352e934c5fff70dc
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Runs `yarn prettier` before every `git commit`
`yarn install` will run `postinstall` which tells `husky` to install hooks specified in `.husky` to `.git/hooks`