### PR TITLE
Keep RouterConfig outside an applications config

### DIFF
--- a/typescript/deploy/src/router/deploy.ts
+++ b/typescript/deploy/src/router/deploy.ts
@@ -16,14 +16,14 @@ import { Router, RouterConfig } from './types';
 
 export abstract class AbacusRouterDeployer<
   Chain extends ChainName,
-  Config extends RouterConfig,
+  Config,
   Addresses,
-> extends AbacusAppDeployer<Chain, Config, Addresses> {
+> extends AbacusAppDeployer<Chain, Config & RouterConfig, Addresses> {
   abstract mustGetRouter(chain: Chain, addresses: Addresses): Router;
 
   constructor(
     multiProvider: MultiProvider<Chain>,
-    configMap: ChainMap<Chain, Config>,
+    configMap: ChainMap<Chain, Config & RouterConfig>,
     options?: DeployerOptions,
   ) {
     const logger = options?.logger || debug('abacus:RouterDeployer');

--- a/typescript/infra/config/environments/dev/controller.ts
+++ b/typescript/infra/config/environments/dev/controller.ts
@@ -17,7 +17,4 @@ const addresses = {
   kovan: defaultControllerConfig,
 };
 
-export const controller: ChainMap<
-  DevChains,
-  Omit<ControllerConfig, 'abacusConnectionManager'>
-> = addresses;
+export const controller: ChainMap<DevChains, ControllerConfig> = addresses;

--- a/typescript/infra/config/environments/test/controller.ts
+++ b/typescript/infra/config/environments/test/controller.ts
@@ -4,10 +4,7 @@ import { ControllerConfig } from '../../../src/controller';
 
 import { TestChains } from './chains';
 
-const defaultControllerConfig: Omit<
-  ControllerConfig,
-  'abacusConnectionManager'
-> = {
+const defaultControllerConfig: ControllerConfig = {
   recoveryManager: '0x4FbBB2b0820CF0cF027BbB58DC7F7f760BC0c57e',
   recoveryTimelock: 180,
 };
@@ -21,7 +18,4 @@ const addresses = {
   test3: defaultControllerConfig,
 };
 
-export const controller: ChainMap<
-  TestChains,
-  Omit<ControllerConfig, 'abacusConnectionManager'>
-> = addresses;
+export const controller: ChainMap<TestChains, ControllerConfig> = addresses;

--- a/typescript/infra/config/environments/testnet/controller.ts
+++ b/typescript/infra/config/environments/testnet/controller.ts
@@ -2,10 +2,7 @@ import { ChainMap } from '@abacus-network/sdk';
 
 import { ControllerConfig } from '../../../src/controller';
 
-const defaultControllerConfig: Omit<
-  ControllerConfig,
-  'abacusConnectionManager'
-> = {
+const defaultControllerConfig: ControllerConfig = {
   recoveryManager: '0xfaD1C94469700833717Fa8a3017278BC1cA8031C',
   recoveryTimelock: 180,
 };
@@ -23,7 +20,5 @@ const addresses = {
   optimismkovan: defaultControllerConfig,
 };
 
-export const controller: ChainMap<
-  keyof typeof addresses,
-  Omit<ControllerConfig, 'abacusConnectionManager'>
-> = addresses;
+export const controller: ChainMap<keyof typeof addresses, ControllerConfig> =
+  addresses;

--- a/typescript/infra/scripts/deploy-controller.ts
+++ b/typescript/infra/scripts/deploy-controller.ts
@@ -1,4 +1,4 @@
-import { AbacusCoreDeployer } from '@abacus-network/deploy';
+import { AbacusCoreDeployer, RouterConfig } from '@abacus-network/deploy';
 import { AbacusCore, ChainMap, objMap } from '@abacus-network/sdk';
 
 import { ControllerConfig, ControllerDeployer } from '../src/controller';
@@ -15,7 +15,7 @@ async function main() {
   const config = getCoreEnvironmentConfig(environment);
   const multiProvider = await config.getMultiProvider();
   const core = AbacusCore.fromEnvironment(environment, multiProvider);
-  const controllerConfig: ChainMap<any, ControllerConfig> =
+  const controllerConfig: ChainMap<any, ControllerConfig & RouterConfig> =
     core.extendWithConnectionManagers(config.controller);
 
   const deployer = new ControllerDeployer(multiProvider, controllerConfig);

--- a/typescript/infra/src/config/environment.ts
+++ b/typescript/infra/src/config/environment.ts
@@ -18,10 +18,7 @@ export type CoreEnvironmentConfig<Chain extends ChainName> = {
   transactionConfigs: EnvironmentConfig<Chain>;
   agent: AgentConfig<Chain>;
   core: ChainMap<Chain, CoreConfig>;
-  controller: ChainMap<
-    Chain,
-    Omit<ControllerConfig, 'abacusConnectionManager'>
-  >;
+  controller: ChainMap<Chain, ControllerConfig>;
   infra: InfrastructureConfig;
   getMultiProvider: () => Promise<MultiProvider<Chain>>;
 };

--- a/typescript/infra/src/controller/check.ts
+++ b/typescript/infra/src/controller/check.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { ethers } from 'ethers';
 
-import { AbacusRouterChecker } from '@abacus-network/deploy';
+import { AbacusRouterChecker, RouterConfig } from '@abacus-network/deploy';
 import {
   ChainMap,
   ChainName,
@@ -18,14 +18,15 @@ export class ControllerChecker<
 > extends AbacusRouterChecker<
   Chain,
   ControllerApp<Chain>,
-  ControllerConfig & {
-    owner: types.Address;
-  }
+  ControllerConfig &
+    RouterConfig & {
+      owner: types.Address;
+    }
 > {
   constructor(
     multiProvider: MultiProvider<any>,
     app: ControllerApp<Chain>,
-    configMap: ChainMap<Chain, ControllerConfig>,
+    configMap: ChainMap<Chain, ControllerConfig & RouterConfig>,
   ) {
     const joinedConfig = objMap(configMap, (_, config) => ({
       ...config,

--- a/typescript/infra/src/controller/deploy.ts
+++ b/typescript/infra/src/controller/deploy.ts
@@ -2,7 +2,7 @@ import { ethers } from 'ethers';
 
 import { ControllerRouter__factory } from '@abacus-network/apps';
 import { UpgradeBeaconController__factory } from '@abacus-network/core';
-import { AbacusRouterDeployer } from '@abacus-network/deploy';
+import { AbacusRouterDeployer, RouterConfig } from '@abacus-network/deploy';
 import {
   ChainName,
   ControllerAddresses,
@@ -17,7 +17,7 @@ export class ControllerDeployer<
 > extends AbacusRouterDeployer<Chain, ControllerConfig, ControllerAddresses> {
   async deployContracts(
     chain: Chain,
-    config: ControllerConfig,
+    config: ControllerConfig & RouterConfig,
   ): Promise<ControllerAddresses> {
     const dc = this.multiProvider.getChainConnection(chain);
     const signer = dc.signer!;

--- a/typescript/infra/src/controller/types.ts
+++ b/typescript/infra/src/controller/types.ts
@@ -1,4 +1,3 @@
-import { RouterConfig } from '@abacus-network/deploy';
 import { types } from '@abacus-network/utils';
 
 export type ControllerConfigAddresses = {
@@ -6,5 +5,6 @@ export type ControllerConfigAddresses = {
   controller?: types.Address;
 };
 
-export type ControllerConfig = RouterConfig &
-  ControllerConfigAddresses & { recoveryTimelock: number };
+export type ControllerConfig = ControllerConfigAddresses & {
+  recoveryTimelock: number;
+};

--- a/typescript/infra/test/controller.test.ts
+++ b/typescript/infra/test/controller.test.ts
@@ -2,6 +2,7 @@ import '@nomiclabs/hardhat-waffle';
 import { ethers } from 'hardhat';
 import path from 'path';
 
+import { RouterConfig } from '@abacus-network/deploy';
 import { getMultiProviderFromConfigAndSigner } from '@abacus-network/deploy/dist/src/utils';
 import {
   AbacusCore,
@@ -23,7 +24,7 @@ describe('controller', async () => {
   let multiProvider: MultiProvider<TestChains>;
   let deployer: ControllerDeployer<TestChains>;
   let addresses: ChainMap<TestChains, ControllerAddresses>;
-  let controllerConfig: ChainMap<TestChains, ControllerConfig>;
+  let controllerConfig: ChainMap<TestChains, ControllerConfig & RouterConfig>;
 
   before(async () => {
     const [signer] = await ethers.getSigners();
@@ -36,8 +37,11 @@ describe('controller', async () => {
       'test',
       multiProvider,
     );
-    controllerConfig = core.extendWithConnectionManagers(config.controller);
-    deployer = new ControllerDeployer(multiProvider, controllerConfig);
+
+    deployer = new ControllerDeployer(
+      multiProvider,
+      core.extendWithConnectionManagers(config.controller),
+    );
   });
 
   it('deploys', async () => {


### PR DESCRIPTION
This PR extracts `RouterConfig` from the applications config type `Config` in `RouterDeployer`, which allows `Config` to be specifiable without the need to specify abacus-specific configuration such as abacusConnectionManagers. It does bring up the question whether 1) this is actually more confusing or 2) where the owner should go. In a world in which most applications would deploy a separate controller, one would probably not want to add `owner` to `Config` either as it is not static. That being said, it does feel like continuously adding abstractions that don't feel perfect.