### PR TITLE
Fix agent config generation

### DIFF
--- a/rust/config/test/test1_config.json
+++ b/rust/config/test/test1_config.json
@@ -11,8 +11,8 @@
         "url": ""
       },
       "addresses": {
-        "inbox": "0xA51c1fc2f0D1a1b8494Ed1FE312d7C3a78Ed91C0",
-        "validatorManager": "0x8A791620dd6260079BF849Dc5567aDC3F2FdC318"
+        "inbox": "0x67d269191c92Caf3cD7723F116c85e6E9bf55933",
+        "validatorManager": "0x7a2088a1bFc9d81c55368AE168C2C02570cB814F"
       }
     },
     "test3": {
@@ -24,8 +24,8 @@
         "url": ""
       },
       "addresses": {
-        "inbox": "0x9A676e781A523b5d0C0e43731313A708CB607508",
-        "validatorManager": "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82"
+        "inbox": "0x5eb3Bc0a489C5A8288765d2336659EbCA68FCd00",
+        "validatorManager": "0x0E801D84Fa97b50751Dbf25036d067dCf18858bF"
       }
     }
   },

--- a/rust/config/test/test2_config.json
+++ b/rust/config/test/test2_config.json
@@ -11,8 +11,8 @@
         "url": ""
       },
       "addresses": {
-        "inbox": "0x67d269191c92Caf3cD7723F116c85e6E9bf55933",
-        "validatorManager": "0x7a2088a1bFc9d81c55368AE168C2C02570cB814F"
+        "inbox": "0xA51c1fc2f0D1a1b8494Ed1FE312d7C3a78Ed91C0",
+        "validatorManager": "0x8A791620dd6260079BF849Dc5567aDC3F2FdC318"
       }
     },
     "test3": {
@@ -24,8 +24,8 @@
         "url": ""
       },
       "addresses": {
-        "inbox": "0xc3e53F4d16Ae77Db1c982e75a937B9f60FE63690",
-        "validatorManager": "0xE6E340D132b5f46d1e472DebcD681B2aBc16e57E"
+        "inbox": "0x809d550fca64d94Bd9F66E60752A544199cfAC3D",
+        "validatorManager": "0x36C02dA8a0983159322a80FFE9F24b1acfF8B570"
       }
     }
   },

--- a/rust/config/test/test3_config.json
+++ b/rust/config/test/test3_config.json
@@ -11,8 +11,8 @@
         "url": ""
       },
       "addresses": {
-        "inbox": "0x5eb3Bc0a489C5A8288765d2336659EbCA68FCd00",
-        "validatorManager": "0x0E801D84Fa97b50751Dbf25036d067dCf18858bF"
+        "inbox": "0x9A676e781A523b5d0C0e43731313A708CB607508",
+        "validatorManager": "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82"
       }
     },
     "test2": {
@@ -24,8 +24,8 @@
         "url": ""
       },
       "addresses": {
-        "inbox": "0x809d550fca64d94Bd9F66E60752A544199cfAC3D",
-        "validatorManager": "0x36C02dA8a0983159322a80FFE9F24b1acfF8B570"
+        "inbox": "0xc3e53F4d16Ae77Db1c982e75a937B9f60FE63690",
+        "validatorManager": "0xE6E340D132b5f46d1e472DebcD681B2aBc16e57E"
       }
     }
   },

--- a/typescript/infra/hardhat.config.ts
+++ b/typescript/infra/hardhat.config.ts
@@ -27,7 +27,8 @@ const chainSummary = async <Chain extends ChainName>(
   const count = (await outbox.tree()).toNumber();
 
   const inboxSummary = async (remote: Chain) => {
-    const inbox = coreContracts.inboxes[remote as Exclude<Chain, Chain>].inbox;
+    const remoteContracts = core.getContracts(remote);
+    const inbox = remoteContracts.inboxes[chain as Exclude<Chain, Chain>].inbox;
     const [inboxCheckpointRoot, inboxCheckpointIndex] =
       await inbox.latestCheckpoint();
     const processFilter = inbox.filters.Process();

--- a/typescript/infra/src/core/deploy.ts
+++ b/typescript/infra/src/core/deploy.ts
@@ -49,7 +49,11 @@ export class AbacusCoreInfraDeployer<
       }
 
       this.multiProvider.remoteChains(chain).forEach((remote) => {
-        const inboxAddresses = addresses.inboxes[remote];
+        // The agent configuration file should contain the `chain`'s inbox on
+        // all the remote chains
+        const remoteAddresses = contractAddresses[remote];
+        const inboxAddresses =
+          remoteAddresses.inboxes[chain as Exclude<Chain, Chain>];
 
         const inbox = {
           domain: chainMetadata[remote].id.toString(),


### PR DESCRIPTION
In a previous PR (https://github.com/abacus-network/abacus-monorepo/pull/343), we changed the semantics of the agent configuration file from `local.json` containing `local`'s inboxes on all the `remote` chains to `remote` inboxes on `local` chain. This PR reverts the original semantics (as well as makes it consistent with the config parsing in the agent code).