### PR TITLE
Fix for vscode extension recommendation.

### DIFF
--- a/rust/.vscode/extensions.json
+++ b/rust/.vscode/extensions.json
@@ -6,7 +6,7 @@
   "recommendations": [
     "panicbit.cargo",
     "tamasfe.even-better-toml",
-    "matklad.rust-analyzer",
+    "rust-lang.rust-analyzer",
   ],
   // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
   "unwantedRecommendations": []


### PR DESCRIPTION
Without this change, vscode emits a warning that maktlad.rust-analyzer
is not in the extensions marketplace.

Since May 16, rust-lang is the new publisher for the
rust-analyzer extension:

https://twitter.com/rust_analyzer/status/1526181089391280128?cxt=HHwWgICwgazniq4qAAAA