### PR TITLE
Remove code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*           @asaj @mattiecnvr @nambrot @tkporter @webbhorn @yorhodes @zmanian
+


### PR DESCRIPTION
Removing code owners for now as to avoid polluted notifications. Authors should opt-in themselves if they would like to be considered as a reviewer