### PR TITLE
Make ChainConnection an ethers Provider/Signer

### DIFF
--- a/typescript/deploy/src/check.ts
+++ b/typescript/deploy/src/check.ts
@@ -56,9 +56,9 @@ export abstract class AbacusAppChecker<
     name: string,
     proxiedAddress: ProxiedAddress,
   ) {
-    const dc = this.multiProvider.getChainConnection(chain);
+    const provider = this.multiProvider.getProvider(chain);
     const implementation = await upgradeBeaconImplementation(
-      dc.provider!,
+      provider,
       proxiedAddress.beacon,
     );
     if (implementation !== proxiedAddress.implementation) {

--- a/typescript/hardhat/src/TestCoreDeploy.ts
+++ b/typescript/hardhat/src/TestCoreDeploy.ts
@@ -38,7 +38,7 @@ export class TestCoreDeploy extends AbacusCoreDeployer<TestChainNames> {
   ): Promise<CoreContractAddresses<TestChainNames, LocalChain>> {
     const addresses = await super.deployContracts(local, config);
 
-    const signer = this.multiProvider.getChainConnection(local).signer!;
+    const signer = this.multiProvider.getSigner(local);
     const outbox = this.outboxFactoryBuilder(signer).attach(
       addresses.outbox.proxy,
     );

--- a/typescript/sdk/src/app.ts
+++ b/typescript/sdk/src/app.ts
@@ -16,10 +16,7 @@ export class AbacusApp<
       objMap(
         contractAddresses,
         (chain, addresses) =>
-          new builder(
-            addresses,
-            multiProvider.getChainConnection(chain).getConnection()!,
-          ),
+          new builder(addresses, multiProvider.getProvider(chain)),
       ),
     );
   }

--- a/typescript/sdk/src/core/message.ts
+++ b/typescript/sdk/src/core/message.ts
@@ -155,7 +155,7 @@ export class AbacusMessage {
     const messages: AbacusMessage[] = [];
     const outbox = new Outbox__factory().interface;
     const chain = resolveDomain(nameOrDomain);
-    const provider = multiProvider.getChainConnection(chain).provider!;
+    const provider = multiProvider.getProvider(chain).provider!;
 
     for (const log of receipt.logs) {
       try {
@@ -228,9 +228,7 @@ export class AbacusMessage {
     nameOrDomain: NameOrDomain,
     transactionHash: string,
   ): Promise<AbacusMessage[]> {
-    const provider = multiProvider.getChainConnection(
-      resolveDomain(nameOrDomain),
-    ).provider!;
+    const provider = multiProvider.getProvider(resolveDomain(nameOrDomain));
     const receipt = await provider.getTransactionReceipt(transactionHash);
     if (!receipt) {
       throw new Error(`No receipt for ${transactionHash} on ${nameOrDomain}`);
@@ -259,9 +257,7 @@ export class AbacusMessage {
     nameOrDomain: NameOrDomain,
     transactionHash: string,
   ): Promise<AbacusMessage> {
-    const provider = multiProvider.getChainConnection(
-      resolveDomain(nameOrDomain),
-    ).provider!;
+    const provider = multiProvider.getProvider(resolveDomain(nameOrDomain));
     const receipt = await provider.getTransactionReceipt(transactionHash);
     if (!receipt) {
       throw new Error(`No receipt for ${transactionHash} on ${nameOrDomain}`);

--- a/typescript/sdk/src/events.ts
+++ b/typescript/sdk/src/events.ts
@@ -179,7 +179,7 @@ async function getPaginatedEvents<T extends Result, U>(
   // or current block number
   let lastBlock;
   if (!endBlock) {
-    const provider = multiprovider.getChainConnection(chain).provider!;
+    const provider = multiprovider.getProvider(chain);
     lastBlock = await provider.getBlockNumber();
   } else {
     lastBlock = endBlock;
@@ -226,7 +226,7 @@ async function findFromPaginatedEvents<T extends Result, U>(
   // or current block number
   let lastBlock;
   if (!endBlock) {
-    const provider = multiprovider.getChainConnection(chain).provider!;
+    const provider = multiprovider.getProvider(chain);
     lastBlock = await provider.getBlockNumber();
   } else {
     lastBlock = endBlock;

--- a/typescript/sdk/src/gas/calculator.ts
+++ b/typescript/sdk/src/gas/calculator.ts
@@ -1,9 +1,10 @@
-import { AbacusCore, MultiProvider, chainMetadata } from '..';
+import { AbacusCore, chainMetadata } from '..';
 import { BigNumber, FixedNumber, ethers } from 'ethers';
 
 import { utils } from '@abacus-network/utils';
 
 import { InboxContracts } from '../core/contracts';
+import { MultiProvider } from '../provider';
 import { ChainName, RemoteChainMap, Remotes } from '../types';
 
 import { DefaultTokenPriceGetter, TokenPriceGetter } from './token-prices';
@@ -252,7 +253,7 @@ export class InterchainGasCalculator<Chain extends ChainName> {
    * @returns The suggested gas price in wei on the destination chain.
    */
   async suggestedGasPrice(chainName: Chain): Promise<BigNumber> {
-    const provider = this.multiProvider.getChainConnection(chainName).provider!;
+    const provider = this.multiProvider.getProvider(chainName);
     return provider.getGasPrice();
   }
 
@@ -282,8 +283,7 @@ export class InterchainGasCalculator<Chain extends ChainName> {
   async estimateHandleGasForMessage<LocalChain extends Chain>(
     message: ParsedMessage<Chain, LocalChain>,
   ): Promise<BigNumber> {
-    const provider = this.multiProvider.getChainConnection(message.destination)
-      .provider!;
+    const provider = this.multiProvider.getProvider(message.destination);
 
     const { inbox } = this.core.getMailboxPair<LocalChain>(
       message.origin,

--- a/typescript/sdk/src/index.ts
+++ b/typescript/sdk/src/index.ts
@@ -38,7 +38,7 @@ export {
   InterchainGasCalculator,
   TokenPriceGetter,
 } from './gas';
-export { ChainConnection, IChainConnection, MultiProvider } from './provider';
+export { IChainConnection, MultiProvider } from './provider';
 export {
   AllChains,
   ChainMap,

--- a/typescript/sdk/src/provider.ts
+++ b/typescript/sdk/src/provider.ts
@@ -1,49 +1,328 @@
-import { ethers } from 'ethers';
+import {
+  EventType,
+  Filter,
+  Listener,
+  Provider,
+  TransactionRequest,
+  TransactionResponse,
+} from '@ethersproject/abstract-provider';
+import { Debugger, debug } from 'debug';
+import { BigNumber, ethers } from 'ethers';
+import { isAddress } from 'ethers/lib/utils';
+import { Deferrable } from 'ethers/lib/utils';
 
 import { ChainMap, ChainName } from './types';
 import { MultiGeneric, objMap } from './utils';
 
+type BlockTag = string | number;
 export interface IChainConnection {
-  provider: ethers.providers.Provider;
+  provider: Provider;
   signer?: ethers.Signer;
   overrides?: ethers.Overrides;
   confirmations?: number;
+  logger?: Debugger;
 }
 
-export class ChainConnection {
-  provider: ethers.providers.Provider;
-  signer?: ethers.Signer;
-  overrides: ethers.Overrides;
-  confirmations: number;
+// TODO: Rename
+/**
+ * WrappedProvider is an ethers.Provider that can also act like a ethers.Signer
+ * if configured. The goal is to allow to create a contract wrapper with this
+ * provider once without having to recreate instances when a signer is "reconnected"
+ * The abstraction isn't perfect as WrappedProvider has to extend from ethers.signer
+ * while it is possible for it to not be configured to be a signer.
+ * Consumers of WrappedProvider should be aware of this distinction and use the
+ * appropriate methods to assert the desired behavior at runtime.
+ */
+export class WrappedProvider<
+  Chain extends ChainName = ChainName,
+> extends ethers.Signer {
+  public readonly chain: Chain;
+  public readonly provider: Provider;
+  public readonly signer?: ethers.Signer;
+  public readonly logger: Debugger;
+  public readonly overrides: ethers.Overrides;
+  public readonly confirmations?: number;
+  public readonly _isProvider: boolean;
 
-  constructor(dc: IChainConnection) {
-    this.provider = dc.provider;
-    this.signer = dc.signer;
-    this.overrides = dc.overrides ?? {};
-    this.confirmations = dc.confirmations ?? 0;
+  constructor(chain: Chain, connection: IChainConnection) {
+    super();
+    this.chain = chain;
+    this.provider = connection.provider;
+    this.signer = connection.signer;
+    this.logger = connection.logger || debug(`abacus:WrappedProvider:${chain}`);
+    this.overrides = connection.overrides || {};
+    this.confirmations = connection.confirmations;
+    this._isProvider = connection.provider._isProvider;
   }
 
-  getConnection = () => this.signer ?? this.provider;
+  perform(method: string, params: any): Promise<any> {
+    this.logger('perform', method, params);
+    // @ts-ignore
+    return this.provider.perform(method, params).then(
+      (result: any) => {
+        this.logger('DEBUG', method, params, '=>', result);
+        return result;
+      },
+      (error: any) => {
+        this.logger('DEBUG:ERROR', method, params, '=>', error);
+        throw error;
+      },
+    );
+  }
 
-  getAddress = () => this.signer?.getAddress();
+  isSigner() {
+    return !!this.signer;
+  }
+
+  getAddress(): Promise<string> {
+    if (!this.signer) {
+      throw new Error('Not a signer');
+    }
+    return this.signer.getAddress();
+  }
+
+  // TODO: Consider adding invariant checking that the signer didn't change in the source of the operation
+  signMessage(message: string | ethers.utils.Bytes): Promise<string> {
+    if (!this.signer) {
+      throw new Error('Not a signer');
+    }
+    return this.signer.signMessage(message);
+  }
+  signTransaction(
+    transaction: ethers.utils.Deferrable<TransactionRequest>,
+  ): Promise<string> {
+    if (!this.signer) {
+      throw new Error('Not a signer');
+    }
+    return this.signer.signTransaction(transaction);
+  }
+  connect(provider: Provider): ethers.Signer {
+    if (!this.signer) {
+      throw new Error('Not a signer');
+    }
+    return this.signer.connect(provider);
+  }
+
+  // All provider implementations
+  // TODO: Elaborate
+  getNetwork() {
+    return this.provider.getNetwork();
+  }
+
+  getBlockNumber() {
+    return this.provider.getBlockNumber();
+  }
+  getCode(
+    addressOrName: string | Promise<string>,
+    blockTag?: BlockTag | Promise<BlockTag> | undefined,
+  ) {
+    return this.provider.getCode(addressOrName, blockTag);
+  }
+  getStorageAt(
+    addressOrName: string | Promise<string>,
+    position: ethers.BigNumberish | Promise<ethers.BigNumberish>,
+    blockTag?: BlockTag | Promise<BlockTag> | undefined,
+  ) {
+    return this.provider.getStorageAt(addressOrName, position, blockTag);
+  }
+  getBlock(blockHashOrBlockTag: BlockTag | Promise<BlockTag>) {
+    return this.provider.getBlock(blockHashOrBlockTag);
+  }
+  getBlockWithTransactions(blockHashOrBlockTag: BlockTag | Promise<BlockTag>) {
+    return this.provider.getBlockWithTransactions(blockHashOrBlockTag);
+  }
+  getTransaction(transactionHash: string) {
+    return this.provider.getTransaction(transactionHash);
+  }
+
+  getTransactionReceipt(transactionHash: string) {
+    return this.provider.getTransactionReceipt(transactionHash);
+  }
+  getLogs(filter: Filter) {
+    return this.provider.getLogs(filter);
+  }
+  lookupAddress(address: string | Promise<string>) {
+    return this.provider.lookupAddress(address);
+  }
+  on(eventName: EventType, listener: Listener) {
+    return this.provider.on(eventName, listener);
+  }
+  once(eventName: EventType, listener: Listener) {
+    return this.provider.once(eventName, listener);
+  }
+  emit(eventName: EventType, ...args: any[]) {
+    return this.provider.emit(eventName, ...args);
+  }
+  listenerCount() {
+    return this.provider.listenerCount();
+  }
+  listeners() {
+    return this.provider.listeners();
+  }
+  off(eventName: EventType, listener: Listener) {
+    return this.provider.off(eventName, listener);
+  }
+  removeAllListeners() {
+    return this.provider.removeAllListeners();
+  }
+  addListener(eventName: EventType, listener: Listener) {
+    return this.provider.addListener(eventName, listener);
+  }
+  removeListener(eventName: EventType, listener: Listener) {
+    return this.provider.removeListener(eventName, listener);
+  }
+  waitForTransaction(
+    transactionHash: string,
+    confirmations?: number | undefined,
+    timeout?: number | undefined,
+  ) {
+    return this.provider.waitForTransaction(
+      transactionHash,
+      confirmations,
+      timeout,
+    );
+  }
+
+  async getBalance(blockTag?: BlockTag | undefined): Promise<BigNumber>;
+  async getBalance(
+    addressOrName: string | Promise<string>,
+    blockTag?: BlockTag | Promise<BlockTag> | undefined,
+  ): Promise<BigNumber>;
+  async getBalance(
+    addressOrNameOrBlockTag: BlockTag | string | Promise<string> | undefined,
+    blockTag?: BlockTag | Promise<BlockTag> | undefined,
+  ) {
+    // TODO: Extract and solidify
+    if (
+      addressOrNameOrBlockTag !== undefined &&
+      typeof blockTag !== 'number' &&
+      // Compiler is unable to to understand that addressOrNameOrBlockTag can't be a number
+      // @ts-ignore
+      isAddress(addressOrNameOrBlockTag)
+    ) {
+      // @ts-ignore
+      return this.provider.getBalance(addressOrNameOrBlockTag, blockTag);
+    } else {
+      return this.provider.getBalance(
+        this.getAddress(),
+        addressOrNameOrBlockTag,
+      );
+    }
+  }
+
+  async getTransactionCount(blockTag?: BlockTag | undefined): Promise<number>;
+  async getTransactionCount(
+    addressOrName: string | Promise<string>,
+    blockTag?: BlockTag | Promise<BlockTag> | undefined,
+  ): Promise<number>;
+  async getTransactionCount(
+    addressOrNameOrBlockTag: BlockTag | string | Promise<string> | undefined,
+    blockTag?: BlockTag | Promise<BlockTag> | undefined,
+  ) {
+    if (
+      addressOrNameOrBlockTag !== undefined &&
+      typeof blockTag !== 'number' &&
+      // Compiler is unable to to understand that addressOrNameOrBlockTag can't be a number
+      // @ts-ignore
+      isAddress(addressOrNameOrBlockTag)
+    ) {
+      return this.provider.getTransactionCount(
+        // @ts-ignore
+        addressOrNameOrBlockTag,
+        blockTag,
+      );
+    } else {
+      return this.provider.getTransactionCount(
+        this.getAddress(),
+        addressOrNameOrBlockTag,
+      );
+    }
+  }
+
+  async sendTransaction(
+    transaction: Deferrable<TransactionRequest>,
+  ): Promise<TransactionResponse>;
+  async sendTransaction(
+    signedTransaction: string | Promise<string>,
+  ): Promise<TransactionResponse>;
+  async sendTransaction(
+    rawOrSignedTransactionPromise:
+      | Deferrable<TransactionRequest>
+      | string
+      | Promise<string>,
+  ) {
+    return Promise.resolve(rawOrSignedTransactionPromise).then(
+      (rawOrSignedTransaction) => {
+        // We are assuming here that a transaction request is an object vs. a string
+        if (typeof rawOrSignedTransaction === 'object') {
+          // We attempt to sign a transaction
+          if (!this.signer) {
+            throw new Error('Not a signer');
+          }
+          return this.signer.sendTransaction(rawOrSignedTransaction);
+        } else {
+          return this.provider.sendTransaction(rawOrSignedTransaction);
+        }
+      },
+    );
+  }
 }
 
+/**
+ * MultiProvider is a critical abstraction for the Abacus' SDK with a goal
+ * of managing providers and signers for all configured chains without the
+ * need to recreate contract wrappers. As per the notes for WrappedProvider,
+ * developers should be aware that the "providers" returned can be ethers.Signer
+ * or not and use the appropriate function to assert this at runtime (i.e. use
+ * getProvider vs getSigner)
+ */
 export class MultiProvider<
   Chain extends ChainName = ChainName,
-> extends MultiGeneric<Chain, ChainConnection> {
+> extends MultiGeneric<Chain, WrappedProvider> {
   constructor(chainConnectionConfigs: ChainMap<Chain, IChainConnection>) {
     super(
       objMap(
         chainConnectionConfigs,
-        (_, connection) => new ChainConnection(connection),
+        (chain, connection) => new WrappedProvider(chain, connection),
       ),
     );
   }
-  getChainConnection(chain: Chain) {
+
+  /**
+   * Returns the provider for a given chain
+   * @param chain The name of the chain for which to get the provider
+   */
+  getProvider(chain: Chain) {
     return this.get(chain);
   }
-  // This doesn't work on hardhat providers so we skip for now
-  // ready() {
-  //   return Promise.all(this.values().map((dc) => dc.provider!.ready));
-  // }
+
+  /**
+   * Same as `getProvider` however asserts that the provider is actually a signer
+   * as well
+   * @param chain The name of the chain for which to get the signer
+   */
+  getSigner(chain: Chain) {
+    const signer = this.get(chain);
+    if (!signer.isSigner()) {
+      throw new Error(`Provider for chain ${chain} does not have a signer`);
+    }
+    return signer;
+  }
+
+  /**
+   * Returns whether there exists a provider for a given chain
+   * @param chain The name of the chain for which to get the provider
+   */
+  hasChainProvider(chain: Chain) {
+    return !!this.get(chain);
+  }
+
+  /**
+   * Returns whether there exists a signer for a given chain
+   * @param chain The name of the chain for which to get the signer
+   */
+  hasChainSigner(chain: Chain) {
+    const signer = this.get(chain);
+    return !!signer && signer.isSigner();
+  }
 }


### PR DESCRIPTION
This PR makes ChainConnection a more fully-featured object and gives it the ability to be passed as an ethers provider/signer to contract wrappers directly. It also sets up the ability to do more things like retries, etc.

This change is API breaking, but may be done with the next planned breaking SDK update.

Related to https://github.com/abacus-network/abacus-monorepo/issues/462