### PR TITLE
Standardize event naming across all contracts

### DIFF
--- a/solidity/app/contracts/AbacusConnectionClient.sol
+++ b/solidity/app/contracts/AbacusConnectionClient.sol
@@ -26,13 +26,13 @@ abstract contract AbacusConnectionClient is OwnableUpgradeable {
      * @notice Emitted when a new abacusConnectionManager is set.
      * @param abacusConnectionManager The address of the abacusConnectionManager contract
      */
-    event SetAbacusConnectionManager(address indexed abacusConnectionManager);
+    event AbacusConnectionManagerSet(address indexed abacusConnectionManager);
 
     /**
      * @notice Emitted when a new Interchain Gas Paymaster is set.
      * @param interchainGasPaymaster The address of the Interchain Gas Paymaster.
      */
-    event SetInterchainGasPaymaster(address indexed interchainGasPaymaster);
+    event InterchainGasPaymasterSet(address indexed interchainGasPaymaster);
 
     // ============ Modifiers ============
 
@@ -78,7 +78,7 @@ abstract contract AbacusConnectionClient is OwnableUpgradeable {
         interchainGasPaymaster = IInterchainGasPaymaster(
             _interchainGasPaymaster
         );
-        emit SetInterchainGasPaymaster(_interchainGasPaymaster);
+        emit InterchainGasPaymasterSet(_interchainGasPaymaster);
     }
 
     // ============ Internal functions ============
@@ -93,7 +93,7 @@ abstract contract AbacusConnectionClient is OwnableUpgradeable {
         abacusConnectionManager = IAbacusConnectionManager(
             _abacusConnectionManager
         );
-        emit SetAbacusConnectionManager(_abacusConnectionManager);
+        emit AbacusConnectionManagerSet(_abacusConnectionManager);
     }
 
     /**

--- a/solidity/app/contracts/Router.sol
+++ b/solidity/app/contracts/Router.sol
@@ -21,7 +21,7 @@ abstract contract Router is AbacusConnectionClient, IMessageRecipient {
      * @param domain The domain of the new router
      * @param router The address of the new router
      */
-    event EnrollRemoteRouter(uint32 indexed domain, bytes32 indexed router);
+    event RemoteRouterEnrolled(uint32 indexed domain, bytes32 indexed router);
 
     // ============ Modifiers ============
     /**
@@ -86,7 +86,7 @@ abstract contract Router is AbacusConnectionClient, IMessageRecipient {
      */
     function _enrollRemoteRouter(uint32 _domain, bytes32 _router) internal {
         routers[_domain] = _router;
-        emit EnrollRemoteRouter(_domain, _router);
+        emit RemoteRouterEnrolled(_domain, _router);
     }
 
     /**

--- a/solidity/app/test/abacusConnectionClient.test.ts
+++ b/solidity/app/test/abacusConnectionClient.test.ts
@@ -51,7 +51,9 @@ describe('AbacusConnectionClient', async () => {
     expect(await connectionClient.abacusConnectionManager()).to.not.equal(
       newConnectionManager,
     );
-    await connectionClient.setAbacusConnectionManager(newConnectionManager);
+    await expect(
+      connectionClient.setAbacusConnectionManager(newConnectionManager),
+    ).to.emit(connectionClient, 'AbacusConnectionManagerSet');
     expect(await connectionClient.abacusConnectionManager()).to.equal(
       newConnectionManager,
     );
@@ -109,7 +111,7 @@ describe('AbacusConnectionClient', async () => {
       await expect(
         connectionClient.setInterchainGasPaymaster(newPaymaster.address),
       )
-        .to.emit(connectionClient, 'SetInterchainGasPaymaster')
+        .to.emit(connectionClient, 'InterchainGasPaymasterSet')
         .withArgs(newPaymaster.address);
     });
 

--- a/solidity/app/test/router.test.ts
+++ b/solidity/app/test/router.test.ts
@@ -88,7 +88,9 @@ describe('Router', async () => {
     await expect(router.mustHaveRemoteRouter(origin)).to.be.revertedWith(
       '!router',
     );
-    await router.enrollRemoteRouter(origin, utils.addressToBytes32(remote));
+    await expect(
+      router.enrollRemoteRouter(origin, utils.addressToBytes32(remote)),
+    ).to.emit(router, 'RemoteRouterEnrolled');
     expect(await router.isRemoteRouter(origin, remoteBytes)).to.equal(true);
     expect(await router.mustHaveRemoteRouter(origin)).to.equal(remoteBytes);
   });

--- a/solidity/core/contracts/AbacusConnectionManager.sol
+++ b/solidity/core/contracts/AbacusConnectionManager.sol
@@ -34,7 +34,7 @@ contract AbacusConnectionManager is IAbacusConnectionManager, Ownable {
      * @notice Emitted when a new Outbox is set.
      * @param outbox the address of the Outbox
      */
-    event NewOutbox(address indexed outbox);
+    event OutboxSet(address indexed outbox);
 
     /**
      * @notice Emitted when a new Inbox is enrolled / added
@@ -63,7 +63,7 @@ contract AbacusConnectionManager is IAbacusConnectionManager, Ownable {
      */
     function setOutbox(address _outbox) external onlyOwner {
         outbox = IOutbox(_outbox);
-        emit NewOutbox(_outbox);
+        emit OutboxSet(_outbox);
     }
 
     /**

--- a/solidity/core/contracts/Mailbox.sol
+++ b/solidity/core/contracts/Mailbox.sol
@@ -34,7 +34,7 @@ abstract contract Mailbox is IMailbox, OwnableUpgradeable {
      * @notice Emitted when the validator manager contract is changed
      * @param validatorManager The address of the new validatorManager
      */
-    event NewValidatorManager(address validatorManager);
+    event ValidatorManagerSet(address validatorManager);
 
     // ============ Modifiers ============
 
@@ -88,6 +88,6 @@ abstract contract Mailbox is IMailbox, OwnableUpgradeable {
             "!contract validatorManager"
         );
         validatorManager = _validatorManager;
-        emit NewValidatorManager(_validatorManager);
+        emit ValidatorManagerSet(_validatorManager);
     }
 }

--- a/solidity/core/contracts/validator-manager/MultisigValidatorManager.sol
+++ b/solidity/core/contracts/validator-manager/MultisigValidatorManager.sol
@@ -40,20 +40,23 @@ abstract contract MultisigValidatorManager is Ownable {
      * @param validator The address of the validator.
      * @param validatorCount The new number of enrolled validators in the validator set.
      */
-    event EnrollValidator(address indexed validator, uint256 validatorCount);
+    event ValidatorEnrolled(address indexed validator, uint256 validatorCount);
 
     /**
      * @notice Emitted when a validator is unenrolled from the validator set.
      * @param validator The address of the validator.
      * @param validatorCount The new number of enrolled validators in the validator set.
      */
-    event UnenrollValidator(address indexed validator, uint256 validatorCount);
+    event ValidatorUnenrolled(
+        address indexed validator,
+        uint256 validatorCount
+    );
 
     /**
      * @notice Emitted when the quorum threshold is set.
      * @param threshold The new quorum threshold.
      */
-    event SetThreshold(uint256 threshold);
+    event ThresholdSet(uint256 threshold);
 
     // ============ Constructor ============
 
@@ -216,7 +219,7 @@ abstract contract MultisigValidatorManager is Ownable {
      */
     function _enrollValidator(address _validator) internal {
         require(validatorSet.add(_validator), "already enrolled");
-        emit EnrollValidator(_validator, validatorCount());
+        emit ValidatorEnrolled(_validator, validatorCount());
     }
 
     /**
@@ -230,7 +233,7 @@ abstract contract MultisigValidatorManager is Ownable {
         require(validatorSet.remove(_validator), "!enrolled");
         uint256 _numValidators = validatorCount();
         require(_numValidators >= threshold, "violates quorum threshold");
-        emit UnenrollValidator(_validator, _numValidators);
+        emit ValidatorUnenrolled(_validator, _numValidators);
     }
 
     /**
@@ -240,7 +243,7 @@ abstract contract MultisigValidatorManager is Ownable {
     function _setThreshold(uint256 _threshold) internal {
         require(_threshold > 0 && _threshold <= validatorCount(), "!range");
         threshold = _threshold;
-        emit SetThreshold(_threshold);
+        emit ThresholdSet(_threshold);
     }
 
     /**

--- a/solidity/core/test/abacusConnectionManager.test.ts
+++ b/solidity/core/test/abacusConnectionManager.test.ts
@@ -60,9 +60,9 @@ describe('AbacusConnectionManager', async () => {
       expect(await connectionManager.outbox()).to.equal(newOutbox.address);
     });
 
-    it('Emits the NewOutbox event', async () => {
+    it('Emits the OutboxSet event', async () => {
       await expect(connectionManager.setOutbox(newOutbox.address))
-        .to.emit(connectionManager, 'NewOutbox')
+        .to.emit(connectionManager, 'OutboxSet')
         .withArgs(newOutbox.address);
     });
 

--- a/solidity/core/test/mailbox.test.ts
+++ b/solidity/core/test/mailbox.test.ts
@@ -35,7 +35,9 @@ describe('Mailbox', async () => {
     it('Allows owner to update the ValidatorManager', async () => {
       const mailboxFactory = new TestMailbox__factory(owner);
       const newValidatorManager = await mailboxFactory.deploy(localDomain);
-      await mailbox.setValidatorManager(newValidatorManager.address);
+      await expect(
+        mailbox.setValidatorManager(newValidatorManager.address),
+      ).to.emit(mailbox, 'ValidatorManagerSet');
       expect(await mailbox.validatorManager()).to.equal(
         newValidatorManager.address,
       );

--- a/solidity/core/test/validator-manager/multisigValidatorManager.test.ts
+++ b/solidity/core/test/validator-manager/multisigValidatorManager.test.ts
@@ -80,7 +80,7 @@ describe('MultisigValidatorManager', async () => {
 
     it('emits the EnrollValidator event', async () => {
       expect(await validatorManager.enrollValidator(validator1.address))
-        .to.emit(validatorManager, 'EnrollValidator')
+        .to.emit(validatorManager, 'ValidatorEnrolled')
         .withArgs(validator1.address, 2);
     });
 
@@ -113,7 +113,7 @@ describe('MultisigValidatorManager', async () => {
 
     it('emits the UnenrollValidator event', async () => {
       expect(await validatorManager.unenrollValidator(validator1.address))
-        .to.emit(validatorManager, 'UnenrollValidator')
+        .to.emit(validatorManager, 'ValidatorUnenrolled')
         .withArgs(validator1.address, 1);
     });
 
@@ -155,7 +155,7 @@ describe('MultisigValidatorManager', async () => {
 
     it('emits the SetThreshold event', async () => {
       expect(await validatorManager.setThreshold(2))
-        .to.emit(validatorManager, 'SetThreshold')
+        .to.emit(validatorManager, 'ThresholdSet')
         .withArgs(2);
     });
 


### PR DESCRIPTION
This PR standardizes on the following naming scheme:
- If the function updates a single value, the function name should be `setX` and the event name should be `XSet`
- If the function adds a value to a set the function name should be `enrollX` and the event name should be `XEnrolled`
- If the function removes a value from a set the function name should be `unenrollX` and the event name should be `XUnenrolled`

Fixes #560 