### PR TITLE
More testnet2 tweaks

### DIFF
--- a/rust/config/testnet2/alfajores_config.json
+++ b/rust/config/testnet2/alfajores_config.json
@@ -34,7 +34,7 @@
       "domain": "80001",
       "name": "mumbai",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "500",
+      "finalityBlocks": "32",
       "connection": {
         "type": "http",
         "url": ""

--- a/rust/config/testnet2/arbitrumrinkeby_config.json
+++ b/rust/config/testnet2/arbitrumrinkeby_config.json
@@ -48,7 +48,7 @@
       "domain": "80001",
       "name": "mumbai",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "500",
+      "finalityBlocks": "32",
       "connection": {
         "type": "http",
         "url": ""

--- a/rust/config/testnet2/bsctestnet_config.json
+++ b/rust/config/testnet2/bsctestnet_config.json
@@ -48,7 +48,7 @@
       "domain": "80001",
       "name": "mumbai",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "500",
+      "finalityBlocks": "32",
       "connection": {
         "type": "http",
         "url": ""

--- a/rust/config/testnet2/fuji_config.json
+++ b/rust/config/testnet2/fuji_config.json
@@ -34,7 +34,7 @@
       "domain": "80001",
       "name": "mumbai",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "500",
+      "finalityBlocks": "32",
       "connection": {
         "type": "http",
         "url": ""

--- a/rust/config/testnet2/kovan_config.json
+++ b/rust/config/testnet2/kovan_config.json
@@ -34,7 +34,7 @@
       "domain": "80001",
       "name": "mumbai",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "500",
+      "finalityBlocks": "32",
       "connection": {
         "type": "http",
         "url": ""

--- a/rust/config/testnet2/mumbai_config.json
+++ b/rust/config/testnet2/mumbai_config.json
@@ -94,7 +94,7 @@
     "domain": "80001",
     "name": "mumbai",
     "rpcStyle": "ethereum",
-    "finalityBlocks": "500",
+    "finalityBlocks": "32",
     "connection": {
       "type": "http",
       "url": ""

--- a/rust/config/testnet2/optimismkovan_config.json
+++ b/rust/config/testnet2/optimismkovan_config.json
@@ -48,7 +48,7 @@
       "domain": "80001",
       "name": "mumbai",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "500",
+      "finalityBlocks": "32",
       "connection": {
         "type": "http",
         "url": ""

--- a/rust/helm/abacus-agent/templates/checkpointer-external-secret.yaml
+++ b/rust/helm/abacus-agent/templates/checkpointer-external-secret.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "abacus-agent.fullname" . }}-checkpointer-external-secret
   labels:
     {{- include "abacus-agent.labels" . | nindent 4 }}
+  annotations:
+    update-on-redeploy: "{{ now }}"
 spec:
   secretStoreRef:
     name: {{ include "abacus-agent.cluster-secret-store.name" . }}

--- a/rust/helm/abacus-agent/templates/external-secret.yaml
+++ b/rust/helm/abacus-agent/templates/external-secret.yaml
@@ -4,6 +4,8 @@ metadata:
   name: {{ include "abacus-agent.fullname" . }}-external-secret
   labels:
     {{- include "abacus-agent.labels" . | nindent 4 }}
+  annotations:
+    update-on-redeploy: "{{ now }}"
 spec:
   secretStoreRef:
     name: {{ include "abacus-agent.cluster-secret-store.name" . }}

--- a/rust/helm/abacus-agent/templates/kathy-external-secret.yaml
+++ b/rust/helm/abacus-agent/templates/kathy-external-secret.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "abacus-agent.fullname" . }}-kathy-external-secret
   labels:
     {{- include "abacus-agent.labels" . | nindent 4 }}
+  annotations:
+    update-on-redeploy: "{{ now }}"
 spec:
   secretStoreRef:
     name: {{ include "abacus-agent.cluster-secret-store.name" . }}

--- a/rust/helm/abacus-agent/templates/relayer-external-secret.yaml
+++ b/rust/helm/abacus-agent/templates/relayer-external-secret.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "abacus-agent.fullname" . }}-relayer-external-secret
   labels:
     {{- include "abacus-agent.labels" . | nindent 4 }}
+  annotations:
+    update-on-redeploy: "{{ now }}"
 spec:
   secretStoreRef:
     name: {{ include "abacus-agent.cluster-secret-store.name" . }}

--- a/rust/helm/abacus-agent/templates/validator-external-secret.yaml
+++ b/rust/helm/abacus-agent/templates/validator-external-secret.yaml
@@ -5,6 +5,8 @@ metadata:
   name: {{ include "abacus-agent.fullname" . }}-validator-external-secret
   labels:
     {{- include "abacus-agent.labels" . | nindent 4 }}
+  annotations:
+    update-on-redeploy: "{{ now }}"
 spec:
   secretStoreRef:
     name: {{ include "abacus-agent.cluster-secret-store.name" . }}

--- a/typescript/infra/config/environments/testnet2/agent.ts
+++ b/typescript/infra/config/environments/testnet2/agent.ts
@@ -9,7 +9,7 @@ export const agent: AgentConfig<TestnetChains> = {
   runEnv: 'testnet2',
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-0b525b2',
+    tag: 'sha-48caaae',
   },
   aws: {
     region: 'us-east-1',
@@ -37,23 +37,20 @@ export const agent: AgentConfig<TestnetChains> = {
   kathy: {
     default: {
       enabled: false,
-      interval: 60 * 2,
+      interval: 60 * 60,
       chat: {
         type: 'static',
-        message: '',
-        recipient: '',
+        message: 'f00',
+        recipient:
+          '0x000000000000000000000000d0d0ff5589da9b43031f8adf576b08476f587191',
       },
     },
     chainOverrides: {
       alfajores: {
         enabled: true,
-        interval: 60 * 2,
-        chat: {
-          type: 'static',
-          message: 'f00',
-          recipient:
-            '0x000000000000000000000000d0d0ff5589da9b43031f8adf576b08476f587191',
-        },
+      },
+      fuji: {
+        enabled: true,
       },
     },
   },

--- a/typescript/infra/config/environments/testnet2/agent.ts
+++ b/typescript/infra/config/environments/testnet2/agent.ts
@@ -9,7 +9,7 @@ export const agent: AgentConfig<TestnetChains> = {
   runEnv: 'testnet2',
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-48caaae',
+    tag: 'sha-d664980',
   },
   aws: {
     region: 'us-east-1',

--- a/typescript/infra/config/environments/testnet2/agent.ts
+++ b/typescript/infra/config/environments/testnet2/agent.ts
@@ -36,21 +36,13 @@ export const agent: AgentConfig<TestnetChains> = {
   },
   kathy: {
     default: {
-      enabled: false,
+      enabled: true,
       interval: 60 * 60,
       chat: {
         type: 'static',
         message: 'f00',
         recipient:
           '0x000000000000000000000000d0d0ff5589da9b43031f8adf576b08476f587191',
-      },
-    },
-    chainOverrides: {
-      alfajores: {
-        enabled: true,
-      },
-      fuji: {
-        enabled: true,
       },
     },
   },

--- a/typescript/infra/config/environments/testnet2/core/rust/alfajores_config.json
+++ b/typescript/infra/config/environments/testnet2/core/rust/alfajores_config.json
@@ -34,7 +34,7 @@
       "domain": "80001",
       "name": "mumbai",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "500",
+      "finalityBlocks": "32",
       "connection": {
         "type": "http",
         "url": ""

--- a/typescript/infra/config/environments/testnet2/core/rust/arbitrumrinkeby_config.json
+++ b/typescript/infra/config/environments/testnet2/core/rust/arbitrumrinkeby_config.json
@@ -48,7 +48,7 @@
       "domain": "80001",
       "name": "mumbai",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "500",
+      "finalityBlocks": "32",
       "connection": {
         "type": "http",
         "url": ""

--- a/typescript/infra/config/environments/testnet2/core/rust/bsctestnet_config.json
+++ b/typescript/infra/config/environments/testnet2/core/rust/bsctestnet_config.json
@@ -48,7 +48,7 @@
       "domain": "80001",
       "name": "mumbai",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "500",
+      "finalityBlocks": "32",
       "connection": {
         "type": "http",
         "url": ""

--- a/typescript/infra/config/environments/testnet2/core/rust/fuji_config.json
+++ b/typescript/infra/config/environments/testnet2/core/rust/fuji_config.json
@@ -34,7 +34,7 @@
       "domain": "80001",
       "name": "mumbai",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "500",
+      "finalityBlocks": "32",
       "connection": {
         "type": "http",
         "url": ""

--- a/typescript/infra/config/environments/testnet2/core/rust/kovan_config.json
+++ b/typescript/infra/config/environments/testnet2/core/rust/kovan_config.json
@@ -34,7 +34,7 @@
       "domain": "80001",
       "name": "mumbai",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "500",
+      "finalityBlocks": "32",
       "connection": {
         "type": "http",
         "url": ""

--- a/typescript/infra/config/environments/testnet2/core/rust/mumbai_config.json
+++ b/typescript/infra/config/environments/testnet2/core/rust/mumbai_config.json
@@ -94,7 +94,7 @@
     "domain": "80001",
     "name": "mumbai",
     "rpcStyle": "ethereum",
-    "finalityBlocks": "500",
+    "finalityBlocks": "32",
     "connection": {
       "type": "http",
       "url": ""

--- a/typescript/infra/config/environments/testnet2/core/rust/optimismkovan_config.json
+++ b/typescript/infra/config/environments/testnet2/core/rust/optimismkovan_config.json
@@ -48,7 +48,7 @@
       "domain": "80001",
       "name": "mumbai",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "500",
+      "finalityBlocks": "32",
       "connection": {
         "type": "http",
         "url": ""

--- a/typescript/infra/src/config/agent.ts
+++ b/typescript/infra/src/config/agent.ts
@@ -13,7 +13,7 @@ import { DeployEnvironment } from './environment';
 // Allows a "default" config to be specified and any per-chain overrides.
 interface ChainOverridableConfig<Chain extends ChainName, T> {
   default: T;
-  chainOverrides?: Partial<ChainMap<Chain, T>>;
+  chainOverrides?: Partial<ChainMap<Chain, Partial<T>>>;
 }
 
 // Returns the default config with any overriden values specified for the provided chain.

--- a/typescript/sdk/src/chain-metadata.ts
+++ b/typescript/sdk/src/chain-metadata.ts
@@ -62,7 +62,7 @@ export const kovan: ChainMetadata = {
 
 export const mumbai: ChainMetadata = {
   id: 80001,
-  finalityBlocks: 500,
+  finalityBlocks: 32,
   paginate: {
     // eth_getLogs and eth_newFilter are limited to a 10,000 blocks range
     blocks: 10000,


### PR DESCRIPTION
* Changes mumbai's blocks till finality to be 32
* Always updates secrets from `external-secrets` upon a fresh agent deploy
* Enables kathy for all envs