### PR TITLE
validator: Ensure non-empty outbox on init.

### DIFF
--- a/rust/agents/validator/src/submit.rs
+++ b/rust/agents/validator/src/submit.rs
@@ -44,11 +44,9 @@ impl ValidatorSubmitter {
             // rather than just the size.  See
             // https://github.com/abacus-network/abacus-monorepo/issues/575 for
             // more details.
-            let mut outbox_count = self.outbox.count().await?;
-            while outbox_count == 0 {
-                info!(outbox_count, "waiting for non-zero outbox size");
-                tokio::time::sleep(Duration::from_secs(self.interval)).await;
-                outbox_count = self.outbox.count().await?;
+            while self.outbox.count().await? == 0 {
+                info!("waiting for non-zero outbox size");
+                sleep(Duration::from_secs(self.interval)).await;
             }
 
             let mut current_index =

--- a/rust/agents/validator/src/submit.rs
+++ b/rust/agents/validator/src/submit.rs
@@ -45,7 +45,7 @@ impl ValidatorSubmitter {
             // https://github.com/abacus-network/abacus-monorepo/issues/575 for
             // more details.
             let mut outbox_count = self.outbox.count().await?;
-            while outbox_count <= 0 {
+            while outbox_count == 0 {
                 info!(outbox_count, "waiting for non-zero outbox size");
                 tokio::time::sleep(Duration::from_secs(self.interval)).await;
                 outbox_count = self.outbox.count().await?;


### PR DESCRIPTION
This addresses the issue described in #575 wherein
validators crash after new contract deployment due to
failed calls on outbox.latest_checkpoint().
The calls fail due to u256 underflow on count()-1,
since count() is zero on init,
and latest_checkpoint() wants to return an
**index**, which is count() - 1.

This PR adds a retry loop just prior to entering
the existing main validator-submit-loop. I chose
to poll outbox.count() rather than try to decode
the error code or revert reason on failed calls
to latest_checkpoint() so that we avoid tightly
coupling this behavior to particular error codes
or messages, and in fact may want to preserve
exisitng behavior when calls to outbox.latest_checkpoint()
fail for other reasons.

Tested with a modified `rust/run-locally.sh` which
asks Kathy to sleep for 5 minutes prior to sending
messages. Without this change, the validator crashes.
With this change, the validator does not crash, and
after 5 minutes, starts signing checkpoints as designed.