### PR TITLE
Add a comment explaining an agent config "rune".

### DIFF
--- a/rust/abacus-base/src/settings/mod.rs
+++ b/rust/abacus-base/src/settings/mod.rs
@@ -36,21 +36,23 @@
 //!
 //! For example, if the config file `example_config.json` is:
 //!
-//!     {
-//!       "environment": "test",
-//!       "signers": {},
-//!       "inboxes": {
-//!         "test2": {
-//!           "domain": "13372",
-//!           ...
-//!         },
-//!         ...
-//!       },
-//!     }
+//! ```json
+//! {
+//!   "environment": "test",
+//!   "signers": {},
+//!   "inboxes": {
+//!     "test2": {
+//!       "domain": "13372",
+//!       ...
+//!     },
+//!     ...
+//!   },
+//! }
+//! ```
 //!
 //! and an environment variable is supplied which defines:
 //!
-//!     `ABC_BASE_INBOXES_TEST2_DOMAIN=1`,
+//!     `ABC_BASE_INBOXES_TEST2_DOMAIN=1`
 //!
 //! then the `decl_settings` macro in `rust/abacus-base/src/macros.rs` will directly
 //! override the 'domain' field found in the json config to be `1`, since the fields

--- a/rust/abacus-base/src/settings/mod.rs
+++ b/rust/abacus-base/src/settings/mod.rs
@@ -17,10 +17,48 @@
 //!
 //! Agents read settings from the config files and/or env.
 //!
-//! Config files are loaded from `rust/config/default` unless specified
-//! otherwise. Currently deployment config directories are labeled by the
-//! timestamp at which they were deployed
-//!
+//! Config files are loaded from `rust/config/default` unless specified otherwise,
+//! i.e.  via $RUN_ENV and $BASE_CONFIG (see the definition of `decl_settings` in
+//! `rust/abacus-base/src/macros.rs`).
+//! 
+//! #### N.B.: Environment variable names correspond 1:1 with cfg file's JSON object hierarchy.
+//! 
+//! In particular, note that any environment variables whose names are prefixed with:
+//! 
+//!     *  `ABC_BASE`
+//! 
+//!     *  `ABC_[agentname]`, where `[agentmame]` is agent-specific, e.g.
+//!        `ABC_VALIDATOR` or `ABC_RELAYER`.
+//! 
+//! will be read as an override to be applied against the hierarchical structure of
+//! the configuration provided by the json config file at
+//! `./config/$RUN_ENV/$BASE_CONFIG`.
+//! 
+//! For example, if the config file `example_config.json` is:
+//! 
+//!     {
+//!       "environment": "test",
+//!       "signers": {},
+//!       "inboxes": {
+//!         "test2": {
+//!           "domain": "13372",
+//!           ...
+//!         },
+//!         ...
+//!       },
+//!     }
+//! 
+//! and an environment variable is supplied which defines:
+//! 
+//!     `ABC_BASE_INBOXES_TEST2_DOMAIN=1`,
+//! 
+//! then the `decl_settings` macro in `rust/abacus-base/src/macros.rs` will directly
+//! override the 'domain' field found in the json config to be `1`, since the fields
+//! in the environment variable name describe the path traversal to arrive at this
+//! field in the JSON config object.
+//! 
+//! ### Configuration value precedence
+//! 
 //! Configuration key/value pairs are loaded in the following order, with later
 //! sources taking precedence:
 //!

--- a/rust/abacus-base/src/settings/mod.rs
+++ b/rust/abacus-base/src/settings/mod.rs
@@ -20,22 +20,22 @@
 //! Config files are loaded from `rust/config/default` unless specified otherwise,
 //! i.e.  via $RUN_ENV and $BASE_CONFIG (see the definition of `decl_settings` in
 //! `rust/abacus-base/src/macros.rs`).
-//! 
+//!
 //! #### N.B.: Environment variable names correspond 1:1 with cfg file's JSON object hierarchy.
-//! 
+//!
 //! In particular, note that any environment variables whose names are prefixed with:
-//! 
+//!
 //!     *  `ABC_BASE`
-//! 
+//!
 //!     *  `ABC_[agentname]`, where `[agentmame]` is agent-specific, e.g.
 //!        `ABC_VALIDATOR` or `ABC_RELAYER`.
-//! 
+//!
 //! will be read as an override to be applied against the hierarchical structure of
 //! the configuration provided by the json config file at
 //! `./config/$RUN_ENV/$BASE_CONFIG`.
-//! 
+//!
 //! For example, if the config file `example_config.json` is:
-//! 
+//!
 //!     {
 //!       "environment": "test",
 //!       "signers": {},
@@ -47,18 +47,18 @@
 //!         ...
 //!       },
 //!     }
-//! 
+//!
 //! and an environment variable is supplied which defines:
-//! 
+//!
 //!     `ABC_BASE_INBOXES_TEST2_DOMAIN=1`,
-//! 
+//!
 //! then the `decl_settings` macro in `rust/abacus-base/src/macros.rs` will directly
 //! override the 'domain' field found in the json config to be `1`, since the fields
 //! in the environment variable name describe the path traversal to arrive at this
 //! field in the JSON config object.
-//! 
+//!
 //! ### Configuration value precedence
-//! 
+//!
 //! Configuration key/value pairs are loaded in the following order, with later
 //! sources taking precedence:
 //!

--- a/rust/abacus-base/src/settings/mod.rs
+++ b/rust/abacus-base/src/settings/mod.rs
@@ -25,10 +25,10 @@
 //!
 //! In particular, note that any environment variables whose names are prefixed with:
 //!
-//!     *  `ABC_BASE`
+//! *  `ABC_BASE`
 //!
-//!     *  `ABC_[agentname]`, where `[agentmame]` is agent-specific, e.g.
-//!        `ABC_VALIDATOR` or `ABC_RELAYER`.
+//! *  `ABC_[agentname]`, where `[agentmame]` is agent-specific, e.g. `ABC_VALIDATOR` or
+//!    `ABC_RELAYER`.
 //!
 //! will be read as an override to be applied against the hierarchical structure of
 //! the configuration provided by the json config file at
@@ -50,14 +50,10 @@
 //! }
 //! ```
 //!
-//! and an environment variable is supplied which defines:
-//!
-//!     `ABC_BASE_INBOXES_TEST2_DOMAIN=1`
-//!
-//! then the `decl_settings` macro in `rust/abacus-base/src/macros.rs` will directly
-//! override the 'domain' field found in the json config to be `1`, since the fields
-//! in the environment variable name describe the path traversal to arrive at this
-//! field in the JSON config object.
+//! and an environment variable is supplied which defines `ABC_BASE_INBOXES_TEST3_DOMAIN=1`, then
+//! the `decl_settings` macro in `rust/abacus-base/src/macros.rs` will directly override the
+//! 'domain' field found in the json config to be `1`, since the fields in the environment variable
+//! name describe the path traversal to arrive at this field in the JSON config object.
 //!
 //! ### Configuration value precedence
 //!


### PR DESCRIPTION
I couldn't find any comment explaining how the correspondence
between environment variable names and JSON config file
hierarchy works. I think you just have to figure this out by
asking someone or internalizing the decl_settings! implementation.

This is really surprising behavior to me, and people might
benefit from a comment in the settings mod.rs file explaining
what's going on at a high level.