### PR TITLE
[validator agent] Do not create inbox contracts if validator agent

### DIFF
--- a/rust/abacus-base/src/settings/mod.rs
+++ b/rust/abacus-base/src/settings/mod.rs
@@ -418,7 +418,7 @@ impl Settings {
     }
 
     /// Try to generate an agent core for a named agent
-    pub async fn try_into_abacus_core(&self, name: &str) -> Result<AbacusAgentCore, Report> {
+    pub async fn try_into_abacus_core(&self, name: &str, parse_inboxes: bool) -> Result<AbacusAgentCore, Report> {
         let metrics = Arc::new(CoreMetrics::new(
             name,
             self.metrics
@@ -434,7 +434,11 @@ impl Settings {
             .await?
             .map(Arc::new);
 
-        let inbox_contracts = self.try_inbox_contracts(db.clone(), &metrics).await?;
+        let inbox_contracts = if parse_inboxes {
+            self.try_inbox_contracts(db.clone(), &metrics).await?
+        } else {
+            HashMap::new()
+        };
 
         Ok(AbacusAgentCore {
             outbox,

--- a/rust/abacus-base/src/settings/mod.rs
+++ b/rust/abacus-base/src/settings/mod.rs
@@ -418,7 +418,11 @@ impl Settings {
     }
 
     /// Try to generate an agent core for a named agent
-    pub async fn try_into_abacus_core(&self, name: &str, parse_inboxes: bool) -> Result<AbacusAgentCore, Report> {
+    pub async fn try_into_abacus_core(
+        &self,
+        name: &str,
+        parse_inboxes: bool,
+    ) -> Result<AbacusAgentCore, Report> {
         let metrics = Arc::new(CoreMetrics::new(
             name,
             self.metrics

--- a/rust/agents/kathy/src/kathy.rs
+++ b/rust/agents/kathy/src/kathy.rs
@@ -38,7 +38,7 @@ impl Agent for Kathy {
         Ok(Self::new(
             settings.interval.parse().expect("invalid u64"),
             settings.chat.into(),
-            settings.base.try_into_abacus_core(Self::AGENT_NAME).await?,
+            settings.base.try_into_abacus_core(Self::AGENT_NAME, true).await?,
         ))
     }
 }

--- a/rust/agents/kathy/src/kathy.rs
+++ b/rust/agents/kathy/src/kathy.rs
@@ -38,7 +38,10 @@ impl Agent for Kathy {
         Ok(Self::new(
             settings.interval.parse().expect("invalid u64"),
             settings.chat.into(),
-            settings.base.try_into_abacus_core(Self::AGENT_NAME, true).await?,
+            settings
+                .base
+                .try_into_abacus_core(Self::AGENT_NAME, true)
+                .await?,
         ))
     }
 }

--- a/rust/agents/relayer/src/relayer.rs
+++ b/rust/agents/relayer/src/relayer.rs
@@ -69,7 +69,7 @@ impl Agent for Relayer {
             multisig_checkpoint_syncer,
             core: settings
                 .as_ref()
-                .try_into_abacus_core(Self::AGENT_NAME)
+                .try_into_abacus_core(Self::AGENT_NAME, true)
                 .await?,
             whitelist,
         })

--- a/rust/agents/validator/src/validator.rs
+++ b/rust/agents/validator/src/validator.rs
@@ -62,7 +62,7 @@ impl Agent for Validator {
         let checkpoint_syncer = settings.checkpointsyncer.try_into_checkpoint_syncer()?;
         let core = settings
             .as_ref()
-            .try_into_abacus_core(Self::AGENT_NAME)
+            .try_into_abacus_core(Self::AGENT_NAME, false)
             .await?;
         Ok(Self::new(
             signer,


### PR DESCRIPTION
This PR skips the creation of the Inbox contract wrappers in the validator agent. That avoids the need to specify RPC urls for them.