### PR TITLE
Use current index for validator latest processed gauge init

### DIFF
--- a/rust/agents/validator/src/submit.rs
+++ b/rust/agents/validator/src/submit.rs
@@ -88,8 +88,11 @@ impl ValidatorSubmitter {
             .await?
             .unwrap_or_default();
 
+        self.metrics
+            .latest_checkpoint_processed
+            .set(current_index as i64);
+
         info!(current_index = current_index, "Starting Validator");
-        let mut initialized = false;
         loop {
             // Check the latest checkpoint
             let latest_checkpoint = self.outbox.latest_checkpoint(reorg_period).await?;
@@ -110,13 +113,8 @@ impl ValidatorSubmitter {
                 self.metrics
                     .latest_checkpoint_processed
                     .set(signed_checkpoint.checkpoint.index as i64);
-            } else if !initialized {
-                self.metrics
-                    .latest_checkpoint_processed
-                    .set(latest_checkpoint.index as i64);
             }
 
-            initialized = true;
             sleep(Duration::from_secs(self.interval)).await;
         }
     }


### PR DESCRIPTION
Minor change to be more clear about intent.