### PR TITLE
Relayer funding infra

### DIFF
--- a/typescript/deploy/src/utils.ts
+++ b/typescript/deploy/src/utils.ts
@@ -9,12 +9,13 @@ export function getArgs() {
   return yargs(process.argv.slice(2))
     .alias('e', 'env')
     .describe('e', 'deploy environment')
+    .string('e')
     .help('h')
     .alias('h', 'help');
 }
 
 export async function getEnvironment(): Promise<string> {
-  return (await getArgs().argv).e as Promise<string>;
+  return (await getArgs().argv).e as string;
 }
 
 export const getMultiProviderFromConfigAndSigner = <Chain extends ChainName>(

--- a/typescript/infra/config/environments/mainnet/funding.ts
+++ b/typescript/infra/config/environments/mainnet/funding.ts
@@ -1,0 +1,12 @@
+import { RelayerFunderConfig } from '../../../src/config/funding';
+
+import { environment } from './chains';
+
+export const relayerFunderConfig: RelayerFunderConfig = {
+  docker: {
+    repo: 'gcr.io/abacus-labs-dev/abacus-monorepo',
+    tag: 'sha-f1e5fb5',
+  },
+  cronSchedule: '*/10 * * * *',
+  namespace: environment,
+};

--- a/typescript/infra/config/environments/mainnet/funding.ts
+++ b/typescript/infra/config/environments/mainnet/funding.ts
@@ -5,7 +5,7 @@ import { environment } from './chains';
 export const relayerFunderConfig: RelayerFunderConfig = {
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-monorepo',
-    tag: 'sha-f1e5fb5',
+    tag: 'sha-29a5b47',
   },
   cronSchedule: '*/10 * * * *',
   namespace: environment,

--- a/typescript/infra/config/environments/mainnet/funding.ts
+++ b/typescript/infra/config/environments/mainnet/funding.ts
@@ -5,7 +5,7 @@ import { environment } from './chains';
 export const relayerFunderConfig: RelayerFunderConfig = {
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-monorepo',
-    tag: 'sha-6bcf986',
+    tag: 'sha-de2ffbd',
   },
   cronSchedule: '*/10 * * * *', // Every 10 minutes
   namespace: environment,

--- a/typescript/infra/config/environments/mainnet/funding.ts
+++ b/typescript/infra/config/environments/mainnet/funding.ts
@@ -5,8 +5,8 @@ import { environment } from './chains';
 export const relayerFunderConfig: RelayerFunderConfig = {
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-monorepo',
-    tag: 'sha-29a5b47',
+    tag: 'sha-5d8d3f1',
   },
-  cronSchedule: '*/10 * * * *',
+  cronSchedule: '*/10 * * * *', // Every 10 minutes
   namespace: environment,
 };

--- a/typescript/infra/config/environments/mainnet/funding.ts
+++ b/typescript/infra/config/environments/mainnet/funding.ts
@@ -5,7 +5,7 @@ import { environment } from './chains';
 export const relayerFunderConfig: RelayerFunderConfig = {
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-monorepo',
-    tag: 'sha-5d8d3f1',
+    tag: 'sha-6bcf986',
   },
   cronSchedule: '*/10 * * * *', // Every 10 minutes
   namespace: environment,

--- a/typescript/infra/config/environments/mainnet/index.ts
+++ b/typescript/infra/config/environments/mainnet/index.ts
@@ -8,6 +8,7 @@ import {
   mainnetConfigs,
 } from './chains';
 import { core } from './core';
+import { relayerFunderConfig } from './funding';
 import { helloWorld } from './helloworld';
 import { infrastructure } from './infrastructure';
 
@@ -20,4 +21,5 @@ export const environment: CoreEnvironmentConfig<MainnetChains> = {
   core,
   infra: infrastructure,
   helloWorld,
+  relayerFunderConfig,
 };

--- a/typescript/infra/config/environments/testnet2/funding.ts
+++ b/typescript/infra/config/environments/testnet2/funding.ts
@@ -1,0 +1,12 @@
+import { RelayerFunderConfig } from '../../../src/config/funding';
+
+import { environment } from './chains';
+
+export const relayerFunderConfig: RelayerFunderConfig = {
+  docker: {
+    repo: 'gcr.io/abacus-labs-dev/abacus-monorepo',
+    tag: 'sha-f1e5fb5',
+  },
+  cronSchedule: '*/10 * * * *',
+  namespace: environment,
+};

--- a/typescript/infra/config/environments/testnet2/funding.ts
+++ b/typescript/infra/config/environments/testnet2/funding.ts
@@ -5,7 +5,7 @@ import { environment } from './chains';
 export const relayerFunderConfig: RelayerFunderConfig = {
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-monorepo',
-    tag: 'sha-f1e5fb5',
+    tag: 'sha-29a5b47',
   },
   cronSchedule: '*/10 * * * *',
   namespace: environment,

--- a/typescript/infra/config/environments/testnet2/funding.ts
+++ b/typescript/infra/config/environments/testnet2/funding.ts
@@ -5,7 +5,7 @@ import { environment } from './chains';
 export const relayerFunderConfig: RelayerFunderConfig = {
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-monorepo',
-    tag: 'sha-6bcf986',
+    tag: 'sha-de2ffbd',
   },
   cronSchedule: '*/10 * * * *', // Every 10 minutes
   namespace: environment,

--- a/typescript/infra/config/environments/testnet2/funding.ts
+++ b/typescript/infra/config/environments/testnet2/funding.ts
@@ -5,8 +5,8 @@ import { environment } from './chains';
 export const relayerFunderConfig: RelayerFunderConfig = {
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-monorepo',
-    tag: 'sha-29a5b47',
+    tag: 'sha-5d8d3f1',
   },
-  cronSchedule: '*/10 * * * *',
+  cronSchedule: '*/10 * * * *', // Every 10 minutes
   namespace: environment,
 };

--- a/typescript/infra/config/environments/testnet2/funding.ts
+++ b/typescript/infra/config/environments/testnet2/funding.ts
@@ -5,7 +5,7 @@ import { environment } from './chains';
 export const relayerFunderConfig: RelayerFunderConfig = {
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-monorepo',
-    tag: 'sha-5d8d3f1',
+    tag: 'sha-6bcf986',
   },
   cronSchedule: '*/10 * * * *', // Every 10 minutes
   namespace: environment,

--- a/typescript/infra/config/environments/testnet2/index.ts
+++ b/typescript/infra/config/environments/testnet2/index.ts
@@ -8,6 +8,7 @@ import {
   testnetConfigs,
 } from './chains';
 import { core } from './core';
+import { relayerFunderConfig } from './funding';
 import { helloWorld } from './helloworld';
 import { infrastructure } from './infrastructure';
 
@@ -20,4 +21,5 @@ export const environment: CoreEnvironmentConfig<TestnetChains> = {
   core,
   infra: infrastructure,
   helloWorld,
+  relayerFunderConfig,
 };

--- a/typescript/infra/helm/helloworld-kathy/templates/cron-job.yaml
+++ b/typescript/infra/helm/helloworld-kathy/templates/cron-job.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: helloworld-kathy
 spec:
-  schedule: {{ .Values.cronjob.schedule }}
+  schedule: "{{ .Values.cronjob.schedule }}"
   successfulJobsHistoryLimit: {{ .Values.cronjob.successfulJobsHistoryLimit }}
   failedJobsHistoryLimit: {{ .Values.cronjob.failedJobsHistoryLimit }}
   concurrencyPolicy: Forbid

--- a/typescript/infra/helm/relayer-funder/Chart.yaml
+++ b/typescript/infra/helm/relayer-funder/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: relayer-funder
+description: Relayer funder
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: '1.16.0'

--- a/typescript/infra/helm/relayer-funder/templates/_helpers.tpl
+++ b/typescript/infra/helm/relayer-funder/templates/_helpers.tpl
@@ -1,0 +1,41 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "abacus.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "abacus.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "abacus.labels" -}}
+helm.sh/chart: {{ include "abacus.chart" . }}
+abacus/deployment: {{ .Values.abacus.runEnv | quote }}
+{{ include "abacus.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "abacus.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "abacus.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+The name of the ClusterSecretStore
+*/}}
+{{- define "abacus.cluster-secret-store.name" -}}
+{{- default "external-secrets-gcp-cluster-secret-store" .Values.externalSecrets.clusterSecretStore }}
+{{- end }}

--- a/typescript/infra/helm/relayer-funder/templates/addresses-external-secret.yaml
+++ b/typescript/infra/helm/relayer-funder/templates/addresses-external-secret.yaml
@@ -1,7 +1,7 @@
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: relayer-funder-external-secret
+  name: relayer-funder-addresses-external-secret
   labels:
     {{- include "abacus.labels" . | nindent 4 }}
 spec:
@@ -11,7 +11,7 @@ spec:
   refreshInterval: "1h"
   # The secret that will be created
   target:
-    name: relayer-funder-secret
+    name: relayer-funder-addresses-secret
     template:
       type: Opaque
       metadata:
@@ -22,6 +22,6 @@ spec:
       data:
         addresses.json: {{ print "'{{ .addresses | toString }}'" }}
   data:
-  - secretKey: deployer_key
+  - secretKey: addresses
     remoteRef:
       key: {{ printf "abacus-%s-key-addresses" .Values.abacus.runEnv }}

--- a/typescript/infra/helm/relayer-funder/templates/cron-job.yaml
+++ b/typescript/infra/helm/relayer-funder/templates/cron-job.yaml
@@ -1,0 +1,30 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: relayer-funder
+spec:
+  schedule: {{ .Values.cronjob.schedule }}
+  successfulJobsHistoryLimit: {{ .Values.cronjob.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.cronjob.failedJobsHistoryLimit }}
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: relayer-funder
+            image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+            imagePullPolicy: IfNotPresent
+            command:
+            - ./node_modules/.bin/ts-node
+            - ./typescript/infra/scripts/funding/fund-relayers-from-deployer.ts
+            - -e
+            - {{ .Values.abacus.runEnv }}
+            - -f
+            - /secret/addresses.json
+            envFrom:
+            - secretRef:
+                name: relayer-funder-secret
+

--- a/typescript/infra/helm/relayer-funder/templates/cron-job.yaml
+++ b/typescript/infra/helm/relayer-funder/templates/cron-job.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: relayer-funder
 spec:
-  schedule: {{ .Values.cronjob.schedule }}
+  schedule: "{{ .Values.cronjob.schedule }}"
   successfulJobsHistoryLimit: {{ .Values.cronjob.successfulJobsHistoryLimit }}
   failedJobsHistoryLimit: {{ .Values.cronjob.failedJobsHistoryLimit }}
   concurrencyPolicy: Forbid
@@ -23,8 +23,15 @@ spec:
             - -e
             - {{ .Values.abacus.runEnv }}
             - -f
-            - /secret/addresses.json
+            - /addresses-secret/addresses.json
             envFrom:
             - secretRef:
-                name: relayer-funder-secret
-
+                name: relayer-funder-env-var-secret
+            volumeMounts:
+            - name: relayer-funder-addresses-secret
+              mountPath: /addresses-secret
+          volumes:
+          - name: relayer-funder-addresses-secret
+            secret:
+              secretName: relayer-funder-addresses-secret
+              defaultMode: 0400

--- a/typescript/infra/helm/relayer-funder/templates/env-var-external-secret.yaml
+++ b/typescript/infra/helm/relayer-funder/templates/env-var-external-secret.yaml
@@ -1,0 +1,45 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: relayer-funder-env-var-external-secret
+  labels:
+    {{- include "abacus.labels" . | nindent 4 }}
+spec:
+  secretStoreRef:
+    name: {{ include "abacus.cluster-secret-store.name" . }}
+    kind: ClusterSecretStore
+  refreshInterval: "1h"
+  # The secret that will be created
+  target:
+    name: relayer-funder-env-var-secret
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          {{- include "abacus.labels" . | nindent 10 }}
+        annotations:
+          update-on-redeploy: "{{ now }}"
+      data:
+        GCP_SECRET_OVERRIDES_ENABLED: "true"
+        GCP_SECRET_OVERRIDE_ABACUS_{{ .Values.abacus.runEnv | upper }}_KEY_DEPLOYER: {{ print "'{{ .deployer_key | toString }}'" }}
+{{/*
+   * For each network, create an environment variable with the RPC endpoint.
+   * The templating of external-secrets will use the data section below to know how
+   * to replace the correct value in the created secret.
+   */}}
+        {{- range .Values.abacus.chains }}
+        GCP_SECRET_OVERRIDE_{{ $.Values.abacus.runEnv | upper }}_RPC_ENDPOINT_{{ . | upper }}: {{ printf "'{{ .%s_rpc | toString }}'" . }}
+        {{- end }}
+  data:
+  - secretKey: deployer_key
+    remoteRef:
+      key: {{ printf "abacus-%s-key-deployer" .Values.abacus.runEnv }}
+{{/*
+   * For each network, load the secret in GCP secret manager with the form: environment-rpc-endpoint-network,
+   * and associate it with the secret key networkname_rpc.
+   */}}
+  {{- range .Values.abacus.chains }}
+  - secretKey: {{ printf "%s_rpc" . }}
+    remoteRef:
+      key: {{ printf "%s-rpc-endpoint-%s" $.Values.abacus.runEnv . }}
+  {{- end }}

--- a/typescript/infra/helm/relayer-funder/templates/external-secret.yaml
+++ b/typescript/infra/helm/relayer-funder/templates/external-secret.yaml
@@ -1,0 +1,27 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: relayer-funder-external-secret
+  labels:
+    {{- include "abacus.labels" . | nindent 4 }}
+spec:
+  secretStoreRef:
+    name: {{ include "abacus.cluster-secret-store.name" . }}
+    kind: ClusterSecretStore
+  refreshInterval: "1h"
+  # The secret that will be created
+  target:
+    name: relayer-funder-secret
+    template:
+      type: Opaque
+      metadata:
+        labels:
+          {{- include "abacus.labels" . | nindent 10 }}
+        annotations:
+          update-on-redeploy: "{{ now }}"
+      data:
+        addresses.json: {{ print "'{{ .addresses | toString }}'" }}
+  data:
+  - secretKey: deployer_key
+    remoteRef:
+      key: {{ printf "abacus-%s-key-addresses" .Values.abacus.runEnv }}

--- a/typescript/infra/helm/relayer-funder/values.yaml
+++ b/typescript/infra/helm/relayer-funder/values.yaml
@@ -1,0 +1,11 @@
+image:
+  repository: gcr.io/abacus-labs-dev/abacus-monorepo
+  tag:
+abacus:
+  runEnv: testnet2
+cronjob:
+  schedule: "*/10 * * * *"
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+externalSecrets:
+  clusterSecretStore:

--- a/typescript/infra/helm/relayer-funder/values.yaml
+++ b/typescript/infra/helm/relayer-funder/values.yaml
@@ -6,7 +6,7 @@ abacus:
   # Used for fetching secrets
   chains: []
 cronjob:
-  schedule: "*/10 * * * *"
+  schedule: "*/10 * * * *" # Every 10 minutes
   successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 1
 externalSecrets:

--- a/typescript/infra/helm/relayer-funder/values.yaml
+++ b/typescript/infra/helm/relayer-funder/values.yaml
@@ -3,6 +3,8 @@ image:
   tag:
 abacus:
   runEnv: testnet2
+  # Used for fetching secrets
+  chains: []
 cronjob:
   schedule: "*/10 * * * *"
   successfulJobsHistoryLimit: 1

--- a/typescript/infra/scripts/fund-relayers-from-deployer.ts
+++ b/typescript/infra/scripts/fund-relayers-from-deployer.ts
@@ -45,9 +45,9 @@ async function fundRelayer(
 
   if (delta.gt(MIN_DELTA)) {
     console.log(
-      `sending ${relayer.chainName} relayer ${ethers.utils.formatEther(
-        delta,
-      )}...`,
+      `sending ${relayer.chainName} relayer ${
+        relayer.address
+      } ${ethers.utils.formatEther(delta)}...`,
     );
     const tx = await chainConnection.signer!.sendTransaction({
       to: relayer.address,
@@ -59,7 +59,9 @@ async function fundRelayer(
   }
 
   console.log(
-    `${relayer.chainName} relayer : ${ethers.utils.formatEther(
+    `${relayer.chainName} relayer ${
+      relayer.address
+    } : ${ethers.utils.formatEther(
       await chainConnection.provider.getBalance(relayer.address),
     )}`,
   );
@@ -91,9 +93,11 @@ async function main() {
     )) {
       await relayerKey.fetch();
       await fundRelayer(chainConnection, relayerKey, desiredBalance);
+      console.log('\n');
     }
 
     console.groupEnd();
+    console.log('\n');
   }
 }
 

--- a/typescript/infra/scripts/funding/deploy-relayer-funder.ts
+++ b/typescript/infra/scripts/funding/deploy-relayer-funder.ts
@@ -1,0 +1,15 @@
+import { runRelayerFunderHelmCommand } from '../../src/funding/deploy-relayer-funder';
+import { HelmCommand } from '../../src/utils/helm';
+import { assertCorrectKubeContext, getEnvironmentConfig } from '../utils';
+
+async function main() {
+  const coreConfig = await getEnvironmentConfig();
+
+  await assertCorrectKubeContext(coreConfig);
+
+  await runRelayerFunderHelmCommand(HelmCommand.InstallOrUpgrade, coreConfig);
+}
+
+main()
+  .then(() => console.log('Deploy successful!'))
+  .catch(console.error);

--- a/typescript/infra/scripts/funding/fund-relayers-from-deployer.ts
+++ b/typescript/infra/scripts/funding/fund-relayers-from-deployer.ts
@@ -70,7 +70,7 @@ async function fundRelayer(
 }
 
 async function main() {
-  let argv = await utils
+  const argv = await utils
     .getArgs()
     .alias('f', 'addresses-file')
     .describe(

--- a/typescript/infra/scripts/funding/fund-relayers-from-deployer.ts
+++ b/typescript/infra/scripts/funding/fund-relayers-from-deployer.ts
@@ -106,7 +106,6 @@ async function main() {
     )) {
       await relayerKey.fetch();
       await fundRelayer(chainConnection, relayerKey, desiredBalance);
-      console.log('\n');
     }
 
     console.groupEnd();

--- a/typescript/infra/scripts/funding/fund-relayers-from-deployer.ts
+++ b/typescript/infra/scripts/funding/fund-relayers-from-deployer.ts
@@ -9,23 +9,25 @@ import { KEY_ROLE_ENUM } from '../../src/agents/roles';
 import { readJSONAtPath } from '../../src/utils/utils';
 import { assertEnvironment, getCoreEnvironmentConfig } from '../utils';
 
-const MIN_DELTA = ethers.utils.parseUnits('0.001', 'ether');
+// Min delta is 1/10 of the desired balance
+const MIN_DELTA_NUMERATOR = ethers.BigNumber.from(1);
+const MIN_DELTA_DENOMINATOR = ethers.BigNumber.from(10);
 
 const desiredBalancePerChain: CompleteChainMap<string> = {
-  celo: '0.05',
-  alfajores: '0.1',
+  celo: '0.1',
+  alfajores: '1',
   avalanche: '0.1',
-  fuji: '0.1',
-  ethereum: '0.1',
+  fuji: '1',
+  ethereum: '0.2',
   kovan: '0.1',
   polygon: '1',
-  mumbai: '0.1',
+  mumbai: '0.5',
   optimism: '0.05',
   optimismkovan: '0.1',
   arbitrum: '0.01',
   arbitrumrinkeby: '0.1',
   bsc: '0.01',
-  bsctestnet: '0.1',
+  bsctestnet: '1',
   // unused
   goerli: '0',
   auroratestnet: '0',
@@ -45,7 +47,11 @@ async function fundRelayer(
   const desiredBalanceEther = ethers.utils.parseUnits(desiredBalance, 'ether');
   const delta = desiredBalanceEther.sub(currentBalance);
 
-  if (delta.gt(MIN_DELTA)) {
+  const minDelta = desiredBalanceEther
+    .mul(MIN_DELTA_NUMERATOR)
+    .div(MIN_DELTA_DENOMINATOR);
+
+  if (delta.gt(minDelta)) {
     console.log(
       `sending ${relayer.chainName} relayer ${
         relayer.address

--- a/typescript/infra/scripts/funding/fund-relayers-from-deployer.ts
+++ b/typescript/infra/scripts/funding/fund-relayers-from-deployer.ts
@@ -58,7 +58,7 @@ async function fundRelayer(
     .mul(MIN_DELTA_NUMERATOR)
     .div(MIN_DELTA_DENOMINATOR);
 
-  let relayerInfo = {
+  const relayerInfo = {
     address: relayer.address,
     chain: relayer.chainName,
   };

--- a/typescript/infra/src/agents/agent.ts
+++ b/typescript/infra/src/agents/agent.ts
@@ -1,6 +1,8 @@
-import { AllChains, ChainName } from '@abacus-network/sdk';
+import { ChainName } from '@abacus-network/sdk';
 
-import { KEY_ROLES, KEY_ROLE_ENUM } from './roles';
+import { assertChain, assertRole } from '../utils/utils';
+
+import { KEY_ROLE_ENUM } from './roles';
 
 export abstract class AgentKey {
   constructor(
@@ -69,22 +71,6 @@ export class ReadOnlyAgentKey extends AgentKey {
       throw Error('Invalid identifier');
     }
     const environment = matches[1];
-
-    const assertRole = (roleStr: string) => {
-      const role = roleStr as KEY_ROLE_ENUM;
-      if (!KEY_ROLES.includes(role)) {
-        throw Error(`Invalid role ${role}`);
-      }
-      return role;
-    };
-
-    const assertChain = (chainStr: string) => {
-      const chain = chainStr as ChainName;
-      if (!AllChains.includes(chain)) {
-        throw Error(`Invalid chain ${chain}`);
-      }
-      return chain;
-    };
 
     // If matches[3] is undefined, this key doesn't have a chainName, and matches[2]
     // is the role name.

--- a/typescript/infra/src/agents/agent.ts
+++ b/typescript/infra/src/agents/agent.ts
@@ -46,6 +46,18 @@ export class ReadOnlyAgentKey extends AgentKey {
     this._address = address;
   }
 
+  /**
+   * Parses the identifier, deriving the environment, role, chain (if any), and index (if any)
+   * and constructs a ReadOnlyAgentKey.
+   * @param identifier The "identifier" of the key. This can come in a few different
+   * flavors, e.g.:
+   * alias/abacus-testnet2-key-kathy (<-- not specific to any chain)
+   * alias/abacus-testnet2-key-optimismkovan-relayer (<-- chain specific)
+   * alias/abacus-testnet2-key-alfajores-validator-0 (<-- chain specific and has an index)
+   * abacus-dev-key-kathy (<-- same idea as above, but without the `alias/` prefix if it's not AWS-based)
+   * @param address The address of the key.
+   * @returns A ReadOnlyAgentKey for the provided identifier and address.
+   */
   static fromSerializedAddress(
     identifier: string,
     address: string,

--- a/typescript/infra/src/config/environment.ts
+++ b/typescript/infra/src/config/environment.ts
@@ -4,6 +4,7 @@ import { ChainMap, ChainName, MultiProvider } from '@abacus-network/sdk';
 import { environments } from '../../config/environments';
 
 import { AgentConfig } from './agent';
+import { RelayerFunderConfig } from './funding';
 import { HelloWorldConfig } from './helloworld';
 import { InfrastructureConfig } from './infrastructure';
 
@@ -22,4 +23,5 @@ export type CoreEnvironmentConfig<Chain extends ChainName> = {
   infra: InfrastructureConfig;
   getMultiProvider: () => Promise<MultiProvider<Chain>>;
   helloWorld?: HelloWorldConfig<Chain>;
+  relayerFunderConfig?: RelayerFunderConfig;
 };

--- a/typescript/infra/src/config/funding.ts
+++ b/typescript/infra/src/config/funding.ts
@@ -1,0 +1,7 @@
+import { DockerConfig } from './agent';
+
+export interface RelayerFunderConfig {
+  docker: DockerConfig;
+  cronSchedule: string;
+  namespace: string;
+}

--- a/typescript/infra/src/funding/deploy-relayer-funder.ts
+++ b/typescript/infra/src/funding/deploy-relayer-funder.ts
@@ -1,0 +1,51 @@
+import { ChainName } from '@abacus-network/sdk';
+
+import { CoreEnvironmentConfig } from '../config';
+import { RelayerFunderConfig } from '../config/funding';
+import { HelmCommand, helmifyValues } from '../utils/helm';
+import { execCmd } from '../utils/utils';
+
+export function runRelayerFunderHelmCommand<Chain extends ChainName>(
+  helmCommand: HelmCommand,
+  coreConfig: CoreEnvironmentConfig<Chain>,
+) {
+  const relayerFunderConfig = getRelayerFunderConfig(coreConfig);
+  const values = getRelayerFunderHelmValues(coreConfig, relayerFunderConfig);
+
+  return execCmd(
+    `helm ${helmCommand} relayer-funder ./helm/relayer-funder --namespace ${
+      relayerFunderConfig.namespace
+    } ${values.join(' ')}`,
+  );
+}
+
+function getRelayerFunderHelmValues<Chain extends ChainName>(
+  coreConfig: CoreEnvironmentConfig<Chain>,
+  relayerFunderConfig: RelayerFunderConfig,
+) {
+  const values = {
+    cronjob: {
+      schedule: relayerFunderConfig.cronSchedule,
+    },
+    abacus: {
+      runEnv: coreConfig.environment,
+    },
+    image: {
+      repository: relayerFunderConfig.docker.repo,
+      tag: relayerFunderConfig.docker.tag,
+    },
+  };
+  return helmifyValues(values);
+}
+
+export function getRelayerFunderConfig(
+  coreConfig: CoreEnvironmentConfig<any>,
+): RelayerFunderConfig {
+  const relayerFunderConfig = coreConfig.relayerFunderConfig;
+  if (!relayerFunderConfig) {
+    throw new Error(
+      `Environment ${coreConfig.environment} does not have a RelayerFunderConfig config`,
+    );
+  }
+  return relayerFunderConfig;
+}

--- a/typescript/infra/src/funding/deploy-relayer-funder.ts
+++ b/typescript/infra/src/funding/deploy-relayer-funder.ts
@@ -29,6 +29,7 @@ function getRelayerFunderHelmValues<Chain extends ChainName>(
     },
     abacus: {
       runEnv: coreConfig.environment,
+      chains: coreConfig.agent.chainNames,
     },
     image: {
       repository: relayerFunderConfig.docker.repo,

--- a/typescript/infra/src/utils/utils.ts
+++ b/typescript/infra/src/utils/utils.ts
@@ -5,6 +5,10 @@ import { ethers } from 'ethers';
 import fs from 'fs';
 import path from 'path';
 
+import { AllChains, ChainName } from '@abacus-network/sdk';
+
+import { KEY_ROLES, KEY_ROLE_ENUM } from '../agents/roles';
+
 export function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -173,4 +177,20 @@ export function readJSONAtPath(filepath: string) {
     throw Error("file doesn't exist");
   }
   return JSON.parse(fs.readFileSync(filepath, 'utf8'));
+}
+
+export function assertRole(roleStr: string) {
+  const role = roleStr as KEY_ROLE_ENUM;
+  if (!KEY_ROLES.includes(role)) {
+    throw Error(`Invalid role ${role}`);
+  }
+  return role;
+}
+
+export function assertChain(chainStr: string) {
+  const chain = chainStr as ChainName;
+  if (!AllChains.includes(chain)) {
+    throw Error(`Invalid chain ${chain}`);
+  }
+  return chain;
 }

--- a/typescript/infra/src/utils/utils.ts
+++ b/typescript/infra/src/utils/utils.ts
@@ -163,7 +163,14 @@ export function writeJSON(directory: string, filename: string, obj: any) {
 
 export function readJSON(directory: string, filename: string) {
   if (!fs.existsSync(directory)) {
+    throw Error("directory doesn't exist");
+  }
+  return readJSONAtPath(path.join(directory, filename));
+}
+
+export function readJSONAtPath(filepath: string) {
+  if (!fs.existsSync(filepath)) {
     throw Error("file doesn't exist");
   }
-  return JSON.parse(fs.readFileSync(path.join(directory, filename), 'utf8'));
+  return JSON.parse(fs.readFileSync(filepath, 'utf8'));
 }


### PR DESCRIPTION
* Deploys a k8s cronjob that will occasionally fund the relayer addresses. The relayer addresses are fetched from GCP secret manager using `external-secrets`. In order to do this, the funding script was adapted to allow a file to be passed in that contains a JSON array of `{"identifier": "...", "address": "0x..."}` objects describing each key. Such an array already exists in GCP secret manager and is generated upon creating keys.
* Changes some of the desired balances. Some of theses should ideally be higher-- the numbers chosen are essentially `min(what can currently be afforded, what they probably should be)`.
* Makes the min delta required for a transaction to be relative to the desired balance. Numerator & denominator was chosen because ethers.BigNumber is integer based only
* Currently deployed on testnet2 & mainnet