### PR TITLE
Add destination domain to InterchainGasPaymaster.payGasFor

### DIFF
--- a/rust/chains/abacus-ethereum/abis/Inbox.abi.json
+++ b/rust/chains/abacus-ethereum/abis/Inbox.abi.json
@@ -27,19 +27,6 @@
     "anonymous": false,
     "inputs": [
       {
-        "indexed": false,
-        "internalType": "address",
-        "name": "validatorManager",
-        "type": "address"
-      }
-    ],
-    "name": "NewValidatorManager",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
         "indexed": true,
         "internalType": "address",
         "name": "previousOwner",
@@ -66,6 +53,19 @@
       }
     ],
     "name": "Process",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "validatorManager",
+        "type": "address"
+      }
+    ],
+    "name": "ValidatorManagerSet",
     "type": "event"
   },
   {

--- a/rust/chains/abacus-ethereum/abis/InboxValidatorManager.abi.json
+++ b/rust/chains/abacus-ethereum/abis/InboxValidatorManager.abi.json
@@ -26,25 +26,6 @@
       {
         "indexed": true,
         "internalType": "address",
-        "name": "validator",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "validatorCount",
-        "type": "uint256"
-      }
-    ],
-    "name": "EnrollValidator",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
         "name": "previousOwner",
         "type": "address"
       },
@@ -68,7 +49,7 @@
         "type": "uint256"
       }
     ],
-    "name": "SetThreshold",
+    "name": "ThresholdSet",
     "type": "event"
   },
   {
@@ -87,7 +68,26 @@
         "type": "uint256"
       }
     ],
-    "name": "UnenrollValidator",
+    "name": "ValidatorEnrolled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "validator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "validatorCount",
+        "type": "uint256"
+      }
+    ],
+    "name": "ValidatorUnenrolled",
     "type": "event"
   },
   {

--- a/rust/chains/abacus-ethereum/abis/InterchainGasPaymaster.abi.json
+++ b/rust/chains/abacus-ethereum/abis/InterchainGasPaymaster.abi.json
@@ -79,6 +79,11 @@
         "internalType": "uint256",
         "name": "_leafIndex",
         "type": "uint256"
+      },
+      {
+        "internalType": "uint32",
+        "name": "_destinationDomain",
+        "type": "uint32"
       }
     ],
     "name": "payGasFor",

--- a/rust/chains/abacus-ethereum/abis/Outbox.abi.json
+++ b/rust/chains/abacus-ethereum/abis/Outbox.abi.json
@@ -71,19 +71,6 @@
     "anonymous": false,
     "inputs": [
       {
-        "indexed": false,
-        "internalType": "address",
-        "name": "validatorManager",
-        "type": "address"
-      }
-    ],
-    "name": "NewValidatorManager",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
         "indexed": true,
         "internalType": "address",
         "name": "previousOwner",
@@ -97,6 +84,19 @@
       }
     ],
     "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "validatorManager",
+        "type": "address"
+      }
+    ],
+    "name": "ValidatorManagerSet",
     "type": "event"
   },
   {

--- a/solidity/app/contracts/Router.sol
+++ b/solidity/app/contracts/Router.sol
@@ -158,7 +158,8 @@ abstract contract Router is AbacusConnectionClient, IMessageRecipient {
         if (_gasPayment > 0) {
             interchainGasPaymaster.payGasFor{value: _gasPayment}(
                 address(_outbox),
-                _leafIndex
+                _leafIndex,
+                _destinationDomain
             );
         }
     }

--- a/solidity/core/contracts/InterchainGasPaymaster.sol
+++ b/solidity/core/contracts/InterchainGasPaymaster.sol
@@ -41,7 +41,7 @@ contract InterchainGasPaymaster is IInterchainGasPaymaster, Ownable {
         uint256 _leafIndex,
         uint32 _destinationDomain
     ) external payable override {
-        // Silence compiler warning. NatSpec @param requires the parameter to be named.
+        // Silence compiler warning. The NatSpec @param requires the parameter to be named.
         // While not used at the moment, future versions of the paymaster may conditionally
         // forward payments depending on the destination domain.
         _destinationDomain;

--- a/solidity/core/contracts/InterchainGasPaymaster.sol
+++ b/solidity/core/contracts/InterchainGasPaymaster.sol
@@ -34,12 +34,18 @@ contract InterchainGasPaymaster is IInterchainGasPaymaster, Ownable {
      * to its destination chain.
      * @param _outbox The address of the Outbox contract.
      * @param _leafIndex The index of the message in the Outbox merkle tree.
+     * @param _destinationDomain The domain of the message's destination chain.
      */
-    function payGasFor(address _outbox, uint256 _leafIndex)
-        external
-        payable
-        override
-    {
+    function payGasFor(
+        address _outbox,
+        uint256 _leafIndex,
+        uint32 _destinationDomain
+    ) external payable override {
+        // Silence compiler warning. NatSpec @param requires the parameter to be named.
+        // While not used at the moment, future versions of the paymaster may conditionally
+        // forward payments depending on the destination domain.
+        _destinationDomain;
+
         emit GasPayment(_outbox, _leafIndex, msg.value);
     }
 

--- a/solidity/core/contracts/test/TestSendReceiver.sol
+++ b/solidity/core/contracts/test/TestSendReceiver.sol
@@ -28,14 +28,23 @@ contract TestSendReceiver is IMessageRecipient {
         if (_blockHashNum % 5 == 0) {
             // Pay in two separate calls, resulting in 2 distinct events
             uint256 _half = _value / 2;
-            _paymaster.payGasFor{value: _half}(address(_outbox), _leafIndex);
+            _paymaster.payGasFor{value: _half}(
+                address(_outbox),
+                _leafIndex,
+                _destinationDomain
+            );
             _paymaster.payGasFor{value: _value - _half}(
                 address(_outbox),
-                _leafIndex
+                _leafIndex,
+                _destinationDomain
             );
         } else {
             // Pay the entire msg.value in one call
-            _paymaster.payGasFor{value: _value}(address(_outbox), _leafIndex);
+            _paymaster.payGasFor{value: _value}(
+                address(_outbox),
+                _leafIndex,
+                _destinationDomain
+            );
         }
     }
 

--- a/solidity/core/interfaces/IInterchainGasPaymaster.sol
+++ b/solidity/core/interfaces/IInterchainGasPaymaster.sol
@@ -7,5 +7,9 @@ pragma solidity >=0.6.11;
  * messages to destination chains.
  */
 interface IInterchainGasPaymaster {
-    function payGasFor(address _outbox, uint256 _leafIndex) external payable;
+    function payGasFor(
+        address _outbox,
+        uint256 _leafIndex,
+        uint32 _destinationDomain
+    ) external payable;
 }

--- a/solidity/core/test/interchainGasPaymaster.test.ts
+++ b/solidity/core/test/interchainGasPaymaster.test.ts
@@ -8,6 +8,7 @@ import {
 } from '../types';
 
 const LEAF_INDEX = 4321;
+const DESTINATION_DOMAIN = 1234;
 const PAYMENT_AMOUNT = 123456789;
 const OWNER = '0xdeadbeef00000000000000000000000000000000';
 const OUTBOX = '0x00000000000000000000000000000000DeaDBeef';
@@ -30,7 +31,9 @@ describe('InterchainGasPaymaster', async () => {
         paymaster.address,
       );
 
-      await paymaster.payGasFor(OUTBOX, LEAF_INDEX, { value: PAYMENT_AMOUNT });
+      await paymaster.payGasFor(OUTBOX, LEAF_INDEX, DESTINATION_DOMAIN, {
+        value: PAYMENT_AMOUNT,
+      });
 
       const paymasterBalanceAfter = await signer.provider!.getBalance(
         paymaster.address,
@@ -43,7 +46,9 @@ describe('InterchainGasPaymaster', async () => {
 
     it('emits the GasPayment event', async () => {
       await expect(
-        paymaster.payGasFor(OUTBOX, LEAF_INDEX, { value: PAYMENT_AMOUNT }),
+        paymaster.payGasFor(OUTBOX, LEAF_INDEX, DESTINATION_DOMAIN, {
+          value: PAYMENT_AMOUNT,
+        }),
       )
         .to.emit(paymaster, 'GasPayment')
         .withArgs(OUTBOX, LEAF_INDEX, PAYMENT_AMOUNT);
@@ -53,7 +58,9 @@ describe('InterchainGasPaymaster', async () => {
   describe('#claim', async () => {
     it('sends the entire balance of the contract to the owner', async () => {
       // First pay some ether into the contract
-      await paymaster.payGasFor(OUTBOX, LEAF_INDEX, { value: PAYMENT_AMOUNT });
+      await paymaster.payGasFor(OUTBOX, LEAF_INDEX, DESTINATION_DOMAIN, {
+        value: PAYMENT_AMOUNT,
+      });
 
       // Set the owner to a different address so we aren't paying gas with the same
       // address we want to observe the balance of


### PR DESCRIPTION
* We anticipate future versions of `InterchainGasPaymaster` to conditionally forward payments depending on the destination chain. We expect this to happen if we decide to support a chain that Gelato does not
* Updates ABIs that the agents use. Some changes are from https://github.com/abacus-network/abacus-monorepo/pull/566, which iirc was awkwardly done post-testnet2 but pre-mainnet. Regardless the agents don't depend on these events (and hopefully never will)