### PR TITLE
Some more correct finality numbers

### DIFF
--- a/rust/config/mainnet/arbitrum_config.json
+++ b/rust/config/mainnet/arbitrum_config.json
@@ -6,7 +6,7 @@
       "domain": "6452067",
       "name": "bsc",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "15",
       "connection": {
         "type": "http",
         "url": ""
@@ -20,7 +20,7 @@
       "domain": "1635148152",
       "name": "avalanche",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -34,7 +34,7 @@
       "domain": "1886350457",
       "name": "polygon",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "500",
+      "finalityBlocks": "256",
       "connection": {
         "type": "http",
         "url": ""
@@ -48,7 +48,7 @@
       "domain": "1667591279",
       "name": "celo",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -76,7 +76,7 @@
       "domain": "6648936",
       "name": "ethereum",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "20",
       "connection": {
         "type": "http",
         "url": ""

--- a/rust/config/mainnet/avalanche_config.json
+++ b/rust/config/mainnet/avalanche_config.json
@@ -6,7 +6,7 @@
       "domain": "6452067",
       "name": "bsc",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "15",
       "connection": {
         "type": "http",
         "url": ""
@@ -20,7 +20,7 @@
       "domain": "1886350457",
       "name": "polygon",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "500",
+      "finalityBlocks": "256",
       "connection": {
         "type": "http",
         "url": ""
@@ -34,7 +34,7 @@
       "domain": "1667591279",
       "name": "celo",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -76,7 +76,7 @@
       "domain": "6648936",
       "name": "ethereum",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "20",
       "connection": {
         "type": "http",
         "url": ""
@@ -94,7 +94,7 @@
     "domain": "1635148152",
     "name": "avalanche",
     "rpcStyle": "ethereum",
-    "finalityBlocks": "0",
+    "finalityBlocks": "1",
     "connection": {
       "type": "http",
       "url": ""

--- a/rust/config/mainnet/bsc_config.json
+++ b/rust/config/mainnet/bsc_config.json
@@ -6,7 +6,7 @@
       "domain": "1635148152",
       "name": "avalanche",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -20,7 +20,7 @@
       "domain": "1886350457",
       "name": "polygon",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "500",
+      "finalityBlocks": "256",
       "connection": {
         "type": "http",
         "url": ""
@@ -34,7 +34,7 @@
       "domain": "1667591279",
       "name": "celo",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -76,7 +76,7 @@
       "domain": "6648936",
       "name": "ethereum",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "20",
       "connection": {
         "type": "http",
         "url": ""
@@ -94,7 +94,7 @@
     "domain": "6452067",
     "name": "bsc",
     "rpcStyle": "ethereum",
-    "finalityBlocks": "7",
+    "finalityBlocks": "15",
     "connection": {
       "type": "http",
       "url": ""

--- a/rust/config/mainnet/celo_config.json
+++ b/rust/config/mainnet/celo_config.json
@@ -6,7 +6,7 @@
       "domain": "6452067",
       "name": "bsc",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "15",
       "connection": {
         "type": "http",
         "url": ""
@@ -20,7 +20,7 @@
       "domain": "1635148152",
       "name": "avalanche",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -34,7 +34,7 @@
       "domain": "1886350457",
       "name": "polygon",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "500",
+      "finalityBlocks": "256",
       "connection": {
         "type": "http",
         "url": ""
@@ -76,7 +76,7 @@
       "domain": "6648936",
       "name": "ethereum",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "20",
       "connection": {
         "type": "http",
         "url": ""
@@ -94,7 +94,7 @@
     "domain": "1667591279",
     "name": "celo",
     "rpcStyle": "ethereum",
-    "finalityBlocks": "0",
+    "finalityBlocks": "1",
     "connection": {
       "type": "http",
       "url": ""

--- a/rust/config/mainnet/ethereum_config.json
+++ b/rust/config/mainnet/ethereum_config.json
@@ -6,7 +6,7 @@
       "domain": "6452067",
       "name": "bsc",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "15",
       "connection": {
         "type": "http",
         "url": ""
@@ -20,7 +20,7 @@
       "domain": "1635148152",
       "name": "avalanche",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -34,7 +34,7 @@
       "domain": "1886350457",
       "name": "polygon",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "500",
+      "finalityBlocks": "256",
       "connection": {
         "type": "http",
         "url": ""
@@ -48,7 +48,7 @@
       "domain": "1667591279",
       "name": "celo",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -94,7 +94,7 @@
     "domain": "6648936",
     "name": "ethereum",
     "rpcStyle": "ethereum",
-    "finalityBlocks": "7",
+    "finalityBlocks": "20",
     "connection": {
       "type": "http",
       "url": ""

--- a/rust/config/mainnet/optimism_config.json
+++ b/rust/config/mainnet/optimism_config.json
@@ -6,7 +6,7 @@
       "domain": "6452067",
       "name": "bsc",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "15",
       "connection": {
         "type": "http",
         "url": ""
@@ -20,7 +20,7 @@
       "domain": "1635148152",
       "name": "avalanche",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -34,7 +34,7 @@
       "domain": "1886350457",
       "name": "polygon",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "500",
+      "finalityBlocks": "256",
       "connection": {
         "type": "http",
         "url": ""
@@ -48,7 +48,7 @@
       "domain": "1667591279",
       "name": "celo",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -76,7 +76,7 @@
       "domain": "6648936",
       "name": "ethereum",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "20",
       "connection": {
         "type": "http",
         "url": ""

--- a/rust/config/mainnet/polygon_config.json
+++ b/rust/config/mainnet/polygon_config.json
@@ -6,7 +6,7 @@
       "domain": "6452067",
       "name": "bsc",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "15",
       "connection": {
         "type": "http",
         "url": ""
@@ -20,7 +20,7 @@
       "domain": "1635148152",
       "name": "avalanche",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -34,7 +34,7 @@
       "domain": "1667591279",
       "name": "celo",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -76,7 +76,7 @@
       "domain": "6648936",
       "name": "ethereum",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "20",
       "connection": {
         "type": "http",
         "url": ""
@@ -94,7 +94,7 @@
     "domain": "1886350457",
     "name": "polygon",
     "rpcStyle": "ethereum",
-    "finalityBlocks": "500",
+    "finalityBlocks": "256",
     "connection": {
       "type": "http",
       "url": ""

--- a/rust/config/testnet2/alfajores_config.json
+++ b/rust/config/testnet2/alfajores_config.json
@@ -6,7 +6,7 @@
       "domain": "3000",
       "name": "kovan",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "15",
       "connection": {
         "type": "http",
         "url": ""
@@ -20,7 +20,7 @@
       "domain": "43113",
       "name": "fuji",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -94,7 +94,7 @@
     "domain": "1000",
     "name": "alfajores",
     "rpcStyle": "ethereum",
-    "finalityBlocks": "0",
+    "finalityBlocks": "1",
     "connection": {
       "type": "http",
       "url": ""

--- a/rust/config/testnet2/arbitrumrinkeby_config.json
+++ b/rust/config/testnet2/arbitrumrinkeby_config.json
@@ -6,7 +6,7 @@
       "domain": "1000",
       "name": "alfajores",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -20,7 +20,7 @@
       "domain": "3000",
       "name": "kovan",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "15",
       "connection": {
         "type": "http",
         "url": ""
@@ -34,7 +34,7 @@
       "domain": "43113",
       "name": "fuji",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""

--- a/rust/config/testnet2/bsctestnet_config.json
+++ b/rust/config/testnet2/bsctestnet_config.json
@@ -6,7 +6,7 @@
       "domain": "1000",
       "name": "alfajores",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -20,7 +20,7 @@
       "domain": "3000",
       "name": "kovan",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "15",
       "connection": {
         "type": "http",
         "url": ""
@@ -34,7 +34,7 @@
       "domain": "43113",
       "name": "fuji",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""

--- a/rust/config/testnet2/fuji_config.json
+++ b/rust/config/testnet2/fuji_config.json
@@ -6,7 +6,7 @@
       "domain": "1000",
       "name": "alfajores",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -20,7 +20,7 @@
       "domain": "3000",
       "name": "kovan",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "15",
       "connection": {
         "type": "http",
         "url": ""
@@ -94,7 +94,7 @@
     "domain": "43113",
     "name": "fuji",
     "rpcStyle": "ethereum",
-    "finalityBlocks": "0",
+    "finalityBlocks": "1",
     "connection": {
       "type": "http",
       "url": ""

--- a/rust/config/testnet2/kovan_config.json
+++ b/rust/config/testnet2/kovan_config.json
@@ -6,7 +6,7 @@
       "domain": "1000",
       "name": "alfajores",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -20,7 +20,7 @@
       "domain": "43113",
       "name": "fuji",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -94,7 +94,7 @@
     "domain": "3000",
     "name": "kovan",
     "rpcStyle": "ethereum",
-    "finalityBlocks": "7",
+    "finalityBlocks": "15",
     "connection": {
       "type": "http",
       "url": ""

--- a/rust/config/testnet2/mumbai_config.json
+++ b/rust/config/testnet2/mumbai_config.json
@@ -6,7 +6,7 @@
       "domain": "1000",
       "name": "alfajores",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -20,7 +20,7 @@
       "domain": "3000",
       "name": "kovan",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "15",
       "connection": {
         "type": "http",
         "url": ""
@@ -34,7 +34,7 @@
       "domain": "43113",
       "name": "fuji",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""

--- a/rust/config/testnet2/optimismkovan_config.json
+++ b/rust/config/testnet2/optimismkovan_config.json
@@ -6,7 +6,7 @@
       "domain": "1000",
       "name": "alfajores",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -20,7 +20,7 @@
       "domain": "3000",
       "name": "kovan",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "15",
       "connection": {
         "type": "http",
         "url": ""
@@ -34,7 +34,7 @@
       "domain": "43113",
       "name": "fuji",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""

--- a/typescript/infra/config/environments/mainnet/agent.ts
+++ b/typescript/infra/config/environments/mainnet/agent.ts
@@ -23,25 +23,25 @@ export const agent: AgentConfig<MainnetChains> = {
     },
     chainOverrides: {
       celo: {
-        reorgPeriod: 0,
+        reorgPeriod: 1,
       },
       ethereum: {
-        reorgPeriod: 7,
+        reorgPeriod: 20,
       },
       bsc: {
-        reorgPeriod: 7,
+        reorgPeriod: 15,
       },
       optimism: {
-        reorgPeriod: 1,
+        reorgPeriod: 20,
       },
       arbitrum: {
         reorgPeriod: 1,
       },
       avalanche: {
-        reorgPeriod: 0,
+        reorgPeriod: 1,
       },
       polygon: {
-        reorgPeriod: 500,
+        reorgPeriod: 256,
       },
     },
   },

--- a/typescript/infra/config/environments/mainnet/core/rust/arbitrum_config.json
+++ b/typescript/infra/config/environments/mainnet/core/rust/arbitrum_config.json
@@ -6,7 +6,7 @@
       "domain": "6452067",
       "name": "bsc",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "15",
       "connection": {
         "type": "http",
         "url": ""
@@ -20,7 +20,7 @@
       "domain": "1635148152",
       "name": "avalanche",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -34,7 +34,7 @@
       "domain": "1886350457",
       "name": "polygon",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "500",
+      "finalityBlocks": "256",
       "connection": {
         "type": "http",
         "url": ""
@@ -48,7 +48,7 @@
       "domain": "1667591279",
       "name": "celo",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -76,7 +76,7 @@
       "domain": "6648936",
       "name": "ethereum",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "15",
       "connection": {
         "type": "http",
         "url": ""

--- a/typescript/infra/config/environments/mainnet/core/rust/avalanche_config.json
+++ b/typescript/infra/config/environments/mainnet/core/rust/avalanche_config.json
@@ -6,7 +6,7 @@
       "domain": "6452067",
       "name": "bsc",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "15",
       "connection": {
         "type": "http",
         "url": ""
@@ -20,7 +20,7 @@
       "domain": "1886350457",
       "name": "polygon",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "500",
+      "finalityBlocks": "256",
       "connection": {
         "type": "http",
         "url": ""
@@ -34,7 +34,7 @@
       "domain": "1667591279",
       "name": "celo",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -76,7 +76,7 @@
       "domain": "6648936",
       "name": "ethereum",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "15",
       "connection": {
         "type": "http",
         "url": ""
@@ -94,7 +94,7 @@
     "domain": "1635148152",
     "name": "avalanche",
     "rpcStyle": "ethereum",
-    "finalityBlocks": "0",
+    "finalityBlocks": "1",
     "connection": {
       "type": "http",
       "url": ""

--- a/typescript/infra/config/environments/mainnet/core/rust/bsc_config.json
+++ b/typescript/infra/config/environments/mainnet/core/rust/bsc_config.json
@@ -6,7 +6,7 @@
       "domain": "1635148152",
       "name": "avalanche",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -20,7 +20,7 @@
       "domain": "1886350457",
       "name": "polygon",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "500",
+      "finalityBlocks": "256",
       "connection": {
         "type": "http",
         "url": ""
@@ -34,7 +34,7 @@
       "domain": "1667591279",
       "name": "celo",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -76,7 +76,7 @@
       "domain": "6648936",
       "name": "ethereum",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "15",
       "connection": {
         "type": "http",
         "url": ""
@@ -94,7 +94,7 @@
     "domain": "6452067",
     "name": "bsc",
     "rpcStyle": "ethereum",
-    "finalityBlocks": "7",
+    "finalityBlocks": "15",
     "connection": {
       "type": "http",
       "url": ""

--- a/typescript/infra/config/environments/mainnet/core/rust/celo_config.json
+++ b/typescript/infra/config/environments/mainnet/core/rust/celo_config.json
@@ -6,7 +6,7 @@
       "domain": "6452067",
       "name": "bsc",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "15",
       "connection": {
         "type": "http",
         "url": ""
@@ -20,7 +20,7 @@
       "domain": "1635148152",
       "name": "avalanche",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -34,7 +34,7 @@
       "domain": "1886350457",
       "name": "polygon",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "500",
+      "finalityBlocks": "256",
       "connection": {
         "type": "http",
         "url": ""
@@ -76,7 +76,7 @@
       "domain": "6648936",
       "name": "ethereum",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "15",
       "connection": {
         "type": "http",
         "url": ""
@@ -94,7 +94,7 @@
     "domain": "1667591279",
     "name": "celo",
     "rpcStyle": "ethereum",
-    "finalityBlocks": "0",
+    "finalityBlocks": "1",
     "connection": {
       "type": "http",
       "url": ""

--- a/typescript/infra/config/environments/mainnet/core/rust/ethereum_config.json
+++ b/typescript/infra/config/environments/mainnet/core/rust/ethereum_config.json
@@ -6,7 +6,7 @@
       "domain": "6452067",
       "name": "bsc",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "15",
       "connection": {
         "type": "http",
         "url": ""
@@ -20,7 +20,7 @@
       "domain": "1635148152",
       "name": "avalanche",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -34,7 +34,7 @@
       "domain": "1886350457",
       "name": "polygon",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "500",
+      "finalityBlocks": "256",
       "connection": {
         "type": "http",
         "url": ""
@@ -48,7 +48,7 @@
       "domain": "1667591279",
       "name": "celo",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -94,7 +94,7 @@
     "domain": "6648936",
     "name": "ethereum",
     "rpcStyle": "ethereum",
-    "finalityBlocks": "7",
+    "finalityBlocks": "15",
     "connection": {
       "type": "http",
       "url": ""

--- a/typescript/infra/config/environments/mainnet/core/rust/optimism_config.json
+++ b/typescript/infra/config/environments/mainnet/core/rust/optimism_config.json
@@ -6,7 +6,7 @@
       "domain": "6452067",
       "name": "bsc",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "15",
       "connection": {
         "type": "http",
         "url": ""
@@ -20,7 +20,7 @@
       "domain": "1635148152",
       "name": "avalanche",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -34,7 +34,7 @@
       "domain": "1886350457",
       "name": "polygon",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "500",
+      "finalityBlocks": "256",
       "connection": {
         "type": "http",
         "url": ""
@@ -48,7 +48,7 @@
       "domain": "1667591279",
       "name": "celo",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -76,7 +76,7 @@
       "domain": "6648936",
       "name": "ethereum",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "15",
       "connection": {
         "type": "http",
         "url": ""

--- a/typescript/infra/config/environments/mainnet/core/rust/polygon_config.json
+++ b/typescript/infra/config/environments/mainnet/core/rust/polygon_config.json
@@ -6,7 +6,7 @@
       "domain": "6452067",
       "name": "bsc",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "15",
       "connection": {
         "type": "http",
         "url": ""
@@ -20,7 +20,7 @@
       "domain": "1635148152",
       "name": "avalanche",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -34,7 +34,7 @@
       "domain": "1667591279",
       "name": "celo",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -76,7 +76,7 @@
       "domain": "6648936",
       "name": "ethereum",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "15",
       "connection": {
         "type": "http",
         "url": ""
@@ -94,7 +94,7 @@
     "domain": "1886350457",
     "name": "polygon",
     "rpcStyle": "ethereum",
-    "finalityBlocks": "500",
+    "finalityBlocks": "256",
     "connection": {
       "type": "http",
       "url": ""

--- a/typescript/infra/config/environments/testnet2/agent.ts
+++ b/typescript/infra/config/environments/testnet2/agent.ts
@@ -23,10 +23,10 @@ export const agent: AgentConfig<TestnetChains> = {
     },
     chainOverrides: {
       alfajores: {
-        reorgPeriod: 0,
+        reorgPeriod: 1,
       },
       fuji: {
-        reorgPeriod: 0,
+        reorgPeriod: 1,
       },
       kovan: {
         reorgPeriod: 7,

--- a/typescript/infra/config/environments/testnet2/core/rust/alfajores_config.json
+++ b/typescript/infra/config/environments/testnet2/core/rust/alfajores_config.json
@@ -6,7 +6,7 @@
       "domain": "3000",
       "name": "kovan",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "15",
       "connection": {
         "type": "http",
         "url": ""
@@ -20,7 +20,7 @@
       "domain": "43113",
       "name": "fuji",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -94,7 +94,7 @@
     "domain": "1000",
     "name": "alfajores",
     "rpcStyle": "ethereum",
-    "finalityBlocks": "0",
+    "finalityBlocks": "1",
     "connection": {
       "type": "http",
       "url": ""

--- a/typescript/infra/config/environments/testnet2/core/rust/arbitrumrinkeby_config.json
+++ b/typescript/infra/config/environments/testnet2/core/rust/arbitrumrinkeby_config.json
@@ -6,7 +6,7 @@
       "domain": "1000",
       "name": "alfajores",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -20,7 +20,7 @@
       "domain": "3000",
       "name": "kovan",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "15",
       "connection": {
         "type": "http",
         "url": ""
@@ -34,7 +34,7 @@
       "domain": "43113",
       "name": "fuji",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""

--- a/typescript/infra/config/environments/testnet2/core/rust/bsctestnet_config.json
+++ b/typescript/infra/config/environments/testnet2/core/rust/bsctestnet_config.json
@@ -6,7 +6,7 @@
       "domain": "1000",
       "name": "alfajores",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -20,7 +20,7 @@
       "domain": "3000",
       "name": "kovan",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "15",
       "connection": {
         "type": "http",
         "url": ""
@@ -34,7 +34,7 @@
       "domain": "43113",
       "name": "fuji",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""

--- a/typescript/infra/config/environments/testnet2/core/rust/fuji_config.json
+++ b/typescript/infra/config/environments/testnet2/core/rust/fuji_config.json
@@ -6,7 +6,7 @@
       "domain": "1000",
       "name": "alfajores",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -20,7 +20,7 @@
       "domain": "3000",
       "name": "kovan",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "15",
       "connection": {
         "type": "http",
         "url": ""
@@ -94,7 +94,7 @@
     "domain": "43113",
     "name": "fuji",
     "rpcStyle": "ethereum",
-    "finalityBlocks": "0",
+    "finalityBlocks": "1",
     "connection": {
       "type": "http",
       "url": ""

--- a/typescript/infra/config/environments/testnet2/core/rust/kovan_config.json
+++ b/typescript/infra/config/environments/testnet2/core/rust/kovan_config.json
@@ -6,7 +6,7 @@
       "domain": "1000",
       "name": "alfajores",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -20,7 +20,7 @@
       "domain": "43113",
       "name": "fuji",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -94,7 +94,7 @@
     "domain": "3000",
     "name": "kovan",
     "rpcStyle": "ethereum",
-    "finalityBlocks": "7",
+    "finalityBlocks": "15",
     "connection": {
       "type": "http",
       "url": ""

--- a/typescript/infra/config/environments/testnet2/core/rust/mumbai_config.json
+++ b/typescript/infra/config/environments/testnet2/core/rust/mumbai_config.json
@@ -6,7 +6,7 @@
       "domain": "1000",
       "name": "alfajores",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -20,7 +20,7 @@
       "domain": "3000",
       "name": "kovan",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "15",
       "connection": {
         "type": "http",
         "url": ""
@@ -34,7 +34,7 @@
       "domain": "43113",
       "name": "fuji",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""

--- a/typescript/infra/config/environments/testnet2/core/rust/optimismkovan_config.json
+++ b/typescript/infra/config/environments/testnet2/core/rust/optimismkovan_config.json
@@ -6,7 +6,7 @@
       "domain": "1000",
       "name": "alfajores",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""
@@ -20,7 +20,7 @@
       "domain": "3000",
       "name": "kovan",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "7",
+      "finalityBlocks": "15",
       "connection": {
         "type": "http",
         "url": ""
@@ -34,7 +34,7 @@
       "domain": "43113",
       "name": "fuji",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "0",
+      "finalityBlocks": "1",
       "connection": {
         "type": "http",
         "url": ""

--- a/typescript/sdk/src/chain-metadata.ts
+++ b/typescript/sdk/src/chain-metadata.ts
@@ -9,12 +9,12 @@ import { ChainMetadata, CompleteChainMap } from './types';
  */
 export const celo: ChainMetadata = {
   id: 0x63656c6f, // b'celo' interpreted as an int
-  finalityBlocks: 0,
+  finalityBlocks: 1,
 };
 
 export const ethereum: ChainMetadata = {
   id: 0x657468, // b'eth' interpreted as an int
-  finalityBlocks: 7,
+  finalityBlocks: 20,
 };
 
 export const arbitrum: ChainMetadata = {
@@ -29,12 +29,12 @@ export const optimism: ChainMetadata = {
 
 export const bsc: ChainMetadata = {
   id: 0x627363, // b'bsc' interpreted as an int
-  finalityBlocks: 7,
+  finalityBlocks: 15,
 };
 
 export const avalanche: ChainMetadata = {
   id: 0x61766178, // b'avax' interpreted as an int
-  finalityBlocks: 0,
+  finalityBlocks: 1,
   paginate: {
     // Needs to be low to avoid RPC timeouts
     blocks: 100000,
@@ -44,7 +44,7 @@ export const avalanche: ChainMetadata = {
 
 export const polygon: ChainMetadata = {
   id: 0x706f6c79, // b'poly' interpreted as an int
-  finalityBlocks: 500,
+  finalityBlocks: 256,
   paginate: {
     // Needs to be low to avoid RPC timeouts
     blocks: 10000,
@@ -57,12 +57,12 @@ export const polygon: ChainMetadata = {
  */
 export const alfajores: ChainMetadata = {
   id: 1000,
-  finalityBlocks: 0,
+  finalityBlocks: 1,
 };
 
 export const fuji: ChainMetadata = {
   id: 43113,
-  finalityBlocks: 0,
+  finalityBlocks: 1,
 };
 
 export const goerli: ChainMetadata = {


### PR DESCRIPTION
* We currently recommend the BSC reorg period in the docs to be 1, but this is clearly not safe https://bscscan.com/blocks_forked. This states https://cryptorating.eu/whitepapers/Binance/BSC_WHITEPAPER.html#security-and-finality the value used should be `(2/3) * validator set size + 1`, which at a validator set size of 21 is 15 blocks.
* Made Optimism consistent with what the docs say, but we need to really clarify if this is the case because I have a feeling the reorg period isn't 20 and is instant as long as the RPC provider isn't fraudulent
* Also made Eth consistent with what the docs say
* Some of the `1` block finalities are really instant, but ig to err on the side of safety it's fine to do 1
* I have not deployed this yet