### PR TITLE
Only pass non-zero reorg periods as lag to latest_checkpoint

### DIFF
--- a/rust/agents/validator/src/submit.rs
+++ b/rust/agents/validator/src/submit.rs
@@ -69,7 +69,11 @@ impl ValidatorSubmitter {
     }
 
     async fn main_task(self) -> Result<()> {
-        let reorg_period = if self.reorg_period == 0 { None } else { Some(self.reorg_period) };
+        let reorg_period = if self.reorg_period == 0 {
+            None
+        } else {
+            Some(self.reorg_period)
+        };
         // Ensure that the outbox has > 0 messages before we enter the main
         // validator submit loop. This is to avoid an underflow / reverted
         // call when we invoke the `outbox.latest_checkpoint()` method,

--- a/rust/agents/validator/src/submit.rs
+++ b/rust/agents/validator/src/submit.rs
@@ -69,7 +69,7 @@ impl ValidatorSubmitter {
     }
 
     async fn main_task(self) -> Result<()> {
-        let reorg_period = Some(self.reorg_period);
+        let reorg_period = if self.reorg_period == 0 { None } else { Some(self.reorg_period) };
         // Ensure that the outbox has > 0 messages before we enter the main
         // validator submit loop. This is to avoid an underflow / reverted
         // call when we invoke the `outbox.latest_checkpoint()` method,


### PR DESCRIPTION
FIxes #675 

If the reorg-period is 0, we would have still calculated the latest blocknumber and pass that explicitly. Instead, we should revert to the default behavior which is to query for the latest state https://github.com/abacus-network/abacus-monorepo/blob/fbf71303139e11fd28430c4819110dbe898e01a6/rust/chains/abacus-ethereum/src/outbox.rs#L313

This may address issues for some RPC providers that are inconsistent across `eth_getBlockNumber` and `eth_call`