### PR TITLE
Add abacus/context label to abacus agent infra

### DIFF
--- a/typescript/infra/helm/relayer-funder/templates/_helpers.tpl
+++ b/typescript/infra/helm/relayer-funder/templates/_helpers.tpl
@@ -18,6 +18,7 @@ Common labels
 {{- define "abacus.labels" -}}
 helm.sh/chart: {{ include "abacus.chart" . }}
 abacus/deployment: {{ .Values.abacus.runEnv | quote }}
+abacus/context: "abacus"
 {{ include "abacus.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}


### PR DESCRIPTION
This is already included in https://github.com/abacus-network/abacus-monorepo/pull/683 here https://github.com/abacus-network/abacus-monorepo/pull/683/files#diff-5e9304f4086b7c967a31deba1a9dc305edfc12e886de770dcc04897d379f8b08R40, but as it seems there is likely to be a testnet2 deployment before https://github.com/abacus-network/abacus-monorepo/pull/683 is merged, it'd be nice to have that deployment include this label, which is used by some of the Grafana dashboards. I've already deployed essentially this change on `testnet2` when testing https://github.com/abacus-network/abacus-monorepo/pull/683 and building the dashboards, so a deployment without https://github.com/abacus-network/abacus-monorepo/pull/683 and this PR is a slight regression from the perspective of the Grafana dashboards