### PR TITLE
Cancel slow pipelines if new commits are pushed

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full

--- a/.github/workflows/monorepo-docker.yml
+++ b/.github/workflows/monorepo-docker.yml
@@ -9,6 +9,9 @@ on:
     paths:
       # For now, because this image is only used to use `infra`, we just build for infra changes
       - 'typescript/infra/**'
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   check-env:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust-docker.yml
+++ b/.github/workflows/rust-docker.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     paths:
       - 'rust/**'
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 jobs:
   check-env:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -11,6 +11,10 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full


### PR DESCRIPTION
Have been noticing that with so many slow workflows it really does not make sense to let them run to completion if we push new commits to a branch. This is a small change based on [this](https://stackoverflow.com/questions/69004608/cancel-previous-pipelines-when-a-new-one-is-triggered-github-actions) which should make them auto-cancel. The benefits are both that it cuts down on CI mins, but also that we are less likely to get throttled and have to wait for things we actually want running to run.