### PR TITLE
Set message_delivered phase correctly in serial_submitter

### DIFF
--- a/rust/abacus-base/src/metrics/core.rs
+++ b/rust/abacus-base/src/metrics/core.rs
@@ -47,6 +47,8 @@ pub struct CoreMetrics {
     submitter_queue_length: IntGaugeVec,
     submitter_queue_duration_histogram: HistogramVec,
 
+    messages_processed_count: IntCounterVec,
+
     outbox_state: IntGaugeVec,
     latest_checkpoint: IntGaugeVec,
 
@@ -173,6 +175,20 @@ impl CoreMetrics {
             registry
         )?;
 
+        // The value of `abacus_last_known_message_leaf_index{phase=message_processed}` should refer
+        // to the maximum leaf index value we ever successfully delivered. Since deliveries can
+        // happen out-of-index-order, we separately track this counter referring to the number of
+        // successfully delivered messages.
+        let messages_processed_count = register_int_counter_vec_with_registry!(
+            opts!(
+                namespaced!("messages_processed_count"),
+                "Number of messages processed",
+                const_labels_ref
+            ),
+            &["outbox_chain", "inbox_chain"],
+            registry
+        )?;
+
         Ok(Self {
             agent_name: for_agent.into(),
             registry,
@@ -186,6 +202,8 @@ impl CoreMetrics {
 
             submitter_queue_length,
             submitter_queue_duration_histogram,
+
+            messages_processed_count,
 
             outbox_state,
             latest_checkpoint,
@@ -306,6 +324,12 @@ impl CoreMetrics {
     /// relevant `submitter`.
     pub fn submitter_queue_duration_histogram(&self) -> HistogramVec {
         self.submitter_queue_duration_histogram.clone()
+    }
+
+    /// Counter for the number of messages successfully submitted by
+    /// this process during its lifetime.
+    pub fn messages_processed_count(&self) -> IntCounterVec {
+        self.messages_processed_count.clone()
     }
 
     /// Histogram for measuring span durations.

--- a/rust/agents/relayer/src/msg/serial_submitter.rs
+++ b/rust/agents/relayer/src/msg/serial_submitter.rs
@@ -6,7 +6,7 @@ use abacus_core::db::AbacusDB;
 use abacus_core::AbacusContract;
 use abacus_core::InboxValidatorManager;
 use eyre::{bail, Result};
-use prometheus::{Histogram, IntGauge};
+use prometheus::{Histogram, IntCounter, IntGauge};
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::TryRecvError;
 use tokio::task::JoinHandle;
@@ -117,9 +117,9 @@ pub(crate) struct SerialSubmitter {
     run_queue: BinaryHeap<SubmitMessageArgs>,
     /// Inbox / InboxValidatorManager on the destination chain.
     inbox_contracts: InboxContracts,
-    // Interface to agent rocks DB for e.g. writing delivery status upon completion.
+    /// Interface to agent rocks DB for e.g. writing delivery status upon completion.
     db: AbacusDB,
-    // Metrics for serial submitter.
+    /// Metrics for serial submitter.
     metrics: SerialSubmitterMetrics,
 }
 
@@ -232,6 +232,12 @@ impl SerialSubmitter {
         self.metrics
             .queue_duration_hist
             .observe((Instant::now() - msg.enqueue_time).as_secs_f64());
+        self.metrics.max_submitted_leaf_index =
+            std::cmp::max(self.metrics.max_submitted_leaf_index, msg.leaf_index);
+        self.metrics
+            .processed_gauge
+            .set(self.metrics.max_submitted_leaf_index as i64);
+        self.metrics.messages_processed_count.inc();
         Ok(())
     }
 }
@@ -241,6 +247,11 @@ pub(crate) struct SerialSubmitterMetrics {
     run_queue_length_gauge: IntGauge,
     wait_queue_length_gauge: IntGauge,
     queue_duration_hist: Histogram,
+    processed_gauge: IntGauge,
+    messages_processed_count: IntCounter,
+
+    /// Private state used to update actual metrics each tick.
+    max_submitted_leaf_index: u32,
 }
 
 impl SerialSubmitterMetrics {
@@ -259,6 +270,15 @@ impl SerialSubmitterMetrics {
             queue_duration_hist: metrics
                 .submitter_queue_duration_histogram()
                 .with_label_values(&[outbox_chain, inbox_chain]),
+            messages_processed_count: metrics
+                .messages_processed_count()
+                .with_label_values(&[outbox_chain, inbox_chain]),
+            processed_gauge: metrics.last_known_message_leaf_index().with_label_values(&[
+                "message_processed",
+                outbox_chain,
+                inbox_chain,
+            ]),
+            max_submitted_leaf_index: 0,
         }
     }
 }

--- a/rust/utils/run-locally/src/main.rs
+++ b/rust/utils/run-locally/src/main.rs
@@ -105,6 +105,10 @@ fn main() -> ExitCode {
         }
     };
 
+    // NOTE: This is defined within the Kathy script and could potentially drift.
+    // TODO: Plumb via environment variable or something.
+    let kathy_messages_per_round = 10;
+
     let log_all = env::var("E2E_LOG_ALL")
         .map(|k| k.parse::<bool>().unwrap())
         .unwrap_or(ci_mode);
@@ -338,6 +342,9 @@ fn main() -> ExitCode {
         if ci_mode {
             // for CI we have to look for the end condition.
             if kathy_done && retry_queues_empty() {
+                assert_termination_invariants(
+                    kathy_rounds.unwrap() as u32 * kathy_messages_per_round,
+                );
                 // end condition reached successfully
                 println!("Kathy completed successfully and the retry queues are empty");
                 break;
@@ -392,6 +399,55 @@ fn prefix_log(output: impl Read, name: &'static str) {
             break;
         }
     }
+}
+
+/// Assert invariants for state upon successful test termination.
+fn assert_termination_invariants(num_expected_messages_processed: u32) {
+    // The value of `abacus_last_known_message_leaf_index{phase=message_processed}` should refer
+    // to the maximum leaf index value we ever successfully delivered. Since deliveries can happen
+    // out-of-index-order, we separately track a counter of the number of successfully delivered
+    // messages. At the end of this test, they should both hold the same value.
+    let msg_processed_max_index: Vec<_> = ureq::get("http://127.0.0.1:9092/metrics")
+        .call()
+        .unwrap()
+        .into_string()
+        .unwrap()
+        .lines()
+        .filter(|l| l.contains(r#"phase="message_processed""#))
+        .filter(|l| l.starts_with("abacus_last_known_message_leaf_index"))
+        .map(|l| l.rsplit_once(' ').unwrap().1.parse::<u32>().unwrap())
+        .collect();
+    assert!(
+        !msg_processed_max_index.is_empty(),
+        "Could not find message_processed phase metric"
+    );
+    // The max index is one less than the number delivered messages, since it is an index into the
+    // outbox merkle tree leafs. Since the metric is parameterized by inbox, and the test
+    // non-deterministically selects the destination inbox between test2 and test3 for the highest
+    // message, we take the max over the metric vector.
+    assert_eq!(
+        msg_processed_max_index.into_iter().max().unwrap(),
+        num_expected_messages_processed - 1
+    );
+
+    // Also ensure the counter is as expected (total number of messages), summed across all inboxes.
+    let msg_processed_count: Vec<_> = ureq::get("http://127.0.0.1:9092/metrics")
+        .call()
+        .unwrap()
+        .into_string()
+        .unwrap()
+        .lines()
+        .filter(|l| l.starts_with("abacus_messages_processed_count"))
+        .map(|l| l.rsplit_once(' ').unwrap().1.parse::<u32>().unwrap())
+        .collect();
+    assert!(
+        !msg_processed_count.is_empty(),
+        "Could not find message_processed phase metric"
+    );
+    assert_eq!(
+        num_expected_messages_processed,
+        msg_processed_count.into_iter().sum::<u32>()
+    );
 }
 
 /// Basically `tail -f file | grep <FILTER>` but also has to write to the file (writes to file all


### PR DESCRIPTION
Update two metrics upon successful delivery of message:

*  counter reflecting number of messages successfully delivered during
   process lifetime

*  gauge of highest leaf index of any message delivered to this inbox so
   far during process lifetime

Also updates run-locally integration test to verify these metric values
upon test termination.