### PR TITLE
Mattie/operational cleanup

### DIFF
--- a/rust/agents/relayer/src/msg/processor.rs
+++ b/rust/agents/relayer/src/msg/processor.rs
@@ -116,7 +116,7 @@ impl MessageProcessor {
             debug!(msg=?msg, "Working on msg");
             msg
         } else {
-            warn!(
+            debug!(
                 "Leaf in db without message idx: {}",
                 self.message_leaf_index
             );
@@ -126,7 +126,7 @@ impl MessageProcessor {
             // here.  For now, optimistically yield and then re-enter the loop in hopes that
             // the DB is now coherent.
             // TODO(webbhorn): Why can't we yield here instead of sleep?
-            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+            tokio::time::sleep(Duration::from_secs(1)).await;
             return Ok(());
         };
 

--- a/rust/chains/abacus-ethereum/src/retrying.rs
+++ b/rust/chains/abacus-ethereum/src/retrying.rs
@@ -10,6 +10,12 @@ use tracing::{debug, info, instrument, trace, warn};
 
 use crate::HttpClientError;
 
+const METHODS_TO_NOT_RETRY: &[&str] = &[
+    "eth_estimateGas",
+    "eth_sendTransaction",
+    "eth_sendRawTransaction",
+];
+
 /// An HTTP Provider with a simple naive exponential backoff built-in
 #[derive(Debug, Clone)]
 pub struct RetryingProvider<P> {
@@ -77,8 +83,6 @@ where
         ProviderError::JsonRpcClientError(Box::new(src))
     }
 }
-
-const METHODS_TO_NOT_RETRY: &[&str] = &["eth_estimateGas", "eth_sendTransaction", "eth_sendRawTransaction"];
 
 #[async_trait]
 impl JsonRpcClient for RetryingProvider<Http> {

--- a/rust/chains/abacus-ethereum/src/retrying.rs
+++ b/rust/chains/abacus-ethereum/src/retrying.rs
@@ -90,7 +90,6 @@ impl JsonRpcClient for RetryingProvider<Http> {
 
     #[instrument(
     level = "debug",
-    err,
     skip(params),
     fields(method = %method, params = %serde_json::to_string(&params).unwrap()))
     ]

--- a/rust/chains/abacus-ethereum/src/validator_manager.rs
+++ b/rust/chains/abacus-ethereum/src/validator_manager.rs
@@ -90,7 +90,7 @@ impl<M> InboxValidatorManager for EthereumInboxValidatorManager<M>
 where
     M: Middleware + 'static,
 {
-    #[tracing::instrument(err, skip(self))]
+    #[tracing::instrument(skip(self))]
     async fn process(
         &self,
         multisig_signed_checkpoint: &MultisigSignedCheckpoint,


### PR DESCRIPTION
- Better retrying provider logic, retry basically everything expect a few specific methods
- Reduce superfluous error and warn logs

Fixes #700 
Fixes #706