### PR TITLE
Workflow cancelling 2

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.ref }}
+  group: e2e-${{ github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/monorepo-docker.yml
+++ b/.github/workflows/monorepo-docker.yml
@@ -10,7 +10,7 @@ on:
       # For now, because this image is only used to use `infra`, we just build for infra changes
       - 'typescript/infra/**'
 concurrency:
-  group: ${{ github.ref }}
+  group: build-push-monorepo-${{ github.ref }}
   cancel-in-progress: true
 jobs:
   check-env:

--- a/.github/workflows/rust-docker.yml
+++ b/.github/workflows/rust-docker.yml
@@ -9,7 +9,7 @@ on:
     paths:
       - 'rust/**'
 concurrency:
-  group: ${{ github.ref }}
+  group: build-push-agents-${{ github.ref }}
   cancel-in-progress: true
 jobs:
   check-env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.ref }}
+  group: rust-${{ github.ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
Whoops, I think the mistake should be obvious from the change, but basically pipelines were cancelling because groups were wrong and causing conflicts. This creates unique group names per workflow.