### PR TITLE
Re-add abacus/context label to agent infra

### DIFF
--- a/rust/helm/abacus-agent/templates/_helpers.tpl
+++ b/rust/helm/abacus-agent/templates/_helpers.tpl
@@ -36,6 +36,7 @@ Common labels
 {{- define "abacus-agent.labels" -}}
 helm.sh/chart: {{ include "abacus-agent.chart" . }}
 abacus/deployment: {{ .Values.abacus.runEnv | quote }}
+abacus/context: "abacus"
 {{ include "abacus-agent.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}


### PR DESCRIPTION
* Looks like #691 was accidentally removed at some point, probably when doing some merging. This just adds it back.