### PR TITLE
reduce "indexed block heights" log level

### DIFF
--- a/rust/abacus-base/src/contract_sync/interchain_gas.rs
+++ b/rust/abacus-base/src/contract_sync/interchain_gas.rs
@@ -59,7 +59,7 @@ where
 
                 let gas_payments = indexer.fetch_gas_payments(from, to).await?;
 
-                info!(
+                debug!(
                     from = from,
                     to = to,
                     gas_payments_count = gas_payments.len(),

--- a/rust/abacus-base/src/contract_sync/outbox.rs
+++ b/rust/abacus-base/src/contract_sync/outbox.rs
@@ -2,7 +2,7 @@ use std::cmp::min;
 use std::time::Duration;
 
 use tokio::time::sleep;
-use tracing::{info, info_span, warn};
+use tracing::{debug, info, info_span, warn};
 use tracing::{instrument::Instrumented, Instrument};
 
 use abacus_core::{chain_from_domain, CommittedMessage, ListValidity, OutboxIndexer};
@@ -92,7 +92,7 @@ where
 
                 let sorted_messages = indexer.fetch_sorted_messages(from, to).await?;
 
-                info!(
+                debug!(
                     from = from,
                     to = to,
                     message_count = sorted_messages.len(),


### PR DESCRIPTION
Noticing a lot of these log messages and the fact we almost always want to filter them out. 