### PR TITLE
Revert "Add "contexts" to infrastructure tooling (#683)"

### DIFF
--- a/rust/ethers-prometheus/src/lib.rs
+++ b/rust/ethers-prometheus/src/lib.rs
@@ -119,8 +119,7 @@ pub const TRANSACTION_SEND_DURATION_SECONDS_HELP: &str =
     "Time taken to submit the transaction (not counting time for it to be included)";
 
 /// Expected label names for the `transaction_send_total` metric.
-pub const TRANSACTION_SEND_TOTAL_LABELS: &[&str] =
-    &["chain", "address_from", "address_to", "txn_status"];
+pub const TRANSACTION_SEND_TOTAL_LABELS: &[&str] = &["chain", "address_from", "address_to"];
 /// Help string for the metric.
 pub const TRANSACTION_SEND_TOTAL_HELP: &str = "Number of transactions sent";
 

--- a/rust/helm/abacus-agent/templates/_helpers.tpl
+++ b/rust/helm/abacus-agent/templates/_helpers.tpl
@@ -36,7 +36,7 @@ Common labels
 {{- define "abacus-agent.labels" -}}
 helm.sh/chart: {{ include "abacus-agent.chart" . }}
 abacus/deployment: {{ .Values.abacus.runEnv | quote }}
-abacus/context: {{ .Values.abacus.context | quote }}
+abacus/context: "abacus"
 {{ include "abacus-agent.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}

--- a/rust/helm/abacus-agent/templates/configmap.yaml
+++ b/rust/helm/abacus-agent/templates/configmap.yaml
@@ -18,9 +18,6 @@ data:
   {{- if .address }}
   ABC_BASE_INBOXES_{{ .name | upper }}_ADDRESS: {{ .address }}
   {{- end }}
-  {{- if .disabled }}
-  ABC_BASE_INBOXES_{{ .name | upper }}_DISABLED: "true"
-  {{- end }}
   {{- end }}
   {{- if .Values.abacus.tracing.uri }}
   ABC_BASE_TRACING_JAEGER_COLLECTOR_URI: {{ .Values.abacus.tracing.uri }}

--- a/rust/helm/abacus-agent/templates/external-secret.yaml
+++ b/rust/helm/abacus-agent/templates/external-secret.yaml
@@ -28,9 +28,7 @@ spec:
    * to replace the correct value in the created secret.
    */}}
         {{- range .Values.abacus.inboxChains }}
-        {{- if not .disabled }}
         ABC_BASE_INBOXES_{{ .name | upper }}_CONNECTION_URL: {{ printf "'{{ .%s_rpc | toString }}'" .name }}
-        {{- end }}
         {{- end }}
   data:
   - secretKey: home_rpc
@@ -41,9 +39,7 @@ spec:
    * and associate it with the secret key networkname_rpc.
    */}}
   {{- range .Values.abacus.inboxChains }}
-  {{- if not .disabled }}
   - secretKey: {{ printf "%s_rpc" .name }}
     remoteRef:
       key: {{ printf "%s-rpc-endpoint-%s" $.Values.abacus.runEnv .name }}
-  {{- end }}
   {{- end }}

--- a/rust/helm/abacus-agent/templates/kathy-external-secret.yaml
+++ b/rust/helm/abacus-agent/templates/kathy-external-secret.yaml
@@ -35,16 +35,16 @@ spec:
   {{- if eq .keyConfig.type "hexKey" }}
   - secretKey: {{ printf "%s_signer_key" .name }}
     remoteRef:
-      key: {{ printf "%s-%s-key-kathy" $.Values.abacus.context $.Values.abacus.runEnv }}
+      key: {{ printf "abacus-%s-key-kathy" $.Values.abacus.runEnv }}
       property: privateKey
   {{- end }}
   {{- end }}
   {{- if .Values.abacus.kathy.aws }}
   - secretKey: aws_access_key_id
     remoteRef:
-      key: {{ printf "%s-%s-kathy-aws-access-key-id" .Values.abacus.context .Values.abacus.runEnv }}
+      key: {{ printf "abacus-%s-kathy-aws-access-key-id" .Values.abacus.runEnv }}
   - secretKey: aws_secret_access_key
     remoteRef:
-      key: {{ printf "%s-%s-kathy-aws-secret-access-key" .Values.abacus.context .Values.abacus.runEnv }}
+      key: {{ printf "abacus-%s-kathy-aws-secret-access-key" .Values.abacus.runEnv }}
   {{- end }}
 {{- end }}

--- a/rust/helm/abacus-agent/templates/relayer-external-secret.yaml
+++ b/rust/helm/abacus-agent/templates/relayer-external-secret.yaml
@@ -35,16 +35,16 @@ spec:
   {{- if eq .keyConfig.type "hexKey" }}
   - secretKey: {{ printf "%s_signer_key" .name }}
     remoteRef:
-      key: {{ printf "%s-%s-key-%s-relayer" $.Values.abacus.context $.Values.abacus.runEnv $.Values.abacus.outboxChain.name }}
+      key: {{ printf "abacus-%s-key-%s-relayer" $.Values.abacus.runEnv $.Values.abacus.outboxChain.name }}
       property: privateKey
   {{- end }}
   {{- end }}
   {{- if .Values.abacus.relayer.aws }}
   - secretKey: aws_access_key_id
     remoteRef:
-      key: {{ printf "%s-%s-%s-relayer-aws-access-key-id" .Values.abacus.context .Values.abacus.runEnv .Values.abacus.outboxChain.name }}
+      key: {{ printf "abacus-%s-%s-relayer-aws-access-key-id" .Values.abacus.runEnv .Values.abacus.outboxChain.name }}
   - secretKey: aws_secret_access_key
     remoteRef:
-      key: {{ printf "%s-%s-%s-relayer-aws-secret-access-key" .Values.abacus.context .Values.abacus.runEnv .Values.abacus.outboxChain.name }}
+      key: {{ printf "abacus-%s-%s-relayer-aws-secret-access-key" .Values.abacus.runEnv .Values.abacus.outboxChain.name }}
   {{- end }}
 {{- end }}

--- a/rust/helm/abacus-agent/templates/validator-configmap.yaml
+++ b/rust/helm/abacus-agent/templates/validator-configmap.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.abacus.validator.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -11,5 +10,4 @@ data:
   validator-{{ $index }}.env: |
 {{- include "abacus-agent.config-env-vars" (dict "config" . "agent_name" "validator" "dot_env_format" true) | indent 4 }}
 {{ $index = add1 $index }}
-{{- end }}
 {{- end }}

--- a/rust/helm/abacus-agent/templates/validator-external-secret.yaml
+++ b/rust/helm/abacus-agent/templates/validator-external-secret.yaml
@@ -39,16 +39,16 @@ spec:
 {{- if eq .validator.type "hexKey" }}
   - secretKey: signer_key_{{ $index }}
     remoteRef:
-      key: {{ printf "%s-%s-key-%s-validator-%d" $.Values.abacus.context $.Values.abacus.runEnv $.Values.abacus.outboxChain.name $index }}
+      key: {{ printf "abacus-%s-key-%s-validator-%d" $.Values.abacus.runEnv $.Values.abacus.outboxChain.name $index }}
       property: privateKey
 {{- end }}
 {{- if or (eq .checkpointSyncer.type "s3") $.Values.abacus.aws }}
   - secretKey: aws_access_key_id_{{ $index }}
     remoteRef:
-      key: {{ printf "%s-%s-%s-validator-%d-aws-access-key-id" $.Values.abacus.context $.Values.abacus.runEnv $.Values.abacus.outboxChain.name $index }}
+      key: {{ printf "abacus-%s-%s-validator-%d-aws-access-key-id" $.Values.abacus.runEnv $.Values.abacus.outboxChain.name $index }}
   - secretKey: aws_secret_access_key_{{ $index }}
     remoteRef:
-      key: {{ printf "%s-%s-%s-validator-%d-aws-secret-access-key" $.Values.abacus.context $.Values.abacus.runEnv $.Values.abacus.outboxChain.name $index }}
+      key: {{ printf "abacus-%s-%s-validator-%d-aws-secret-access-key" $.Values.abacus.runEnv $.Values.abacus.outboxChain.name $index }}
 {{- end }}
 {{ $index = add1 $index }}
 {{- end }}

--- a/rust/helm/abacus-agent/values.yaml
+++ b/rust/helm/abacus-agent/values.yaml
@@ -30,7 +30,6 @@ storage:
 abacus:
   # Sets the config folder to use
   runEnv: "default"
-  context: "abacus"
   # Sets the base config to be used (switch between Homes)
   baseConfig: "base.json"
   # Set the DB location to be the volume
@@ -59,7 +58,6 @@ abacus:
   # -- Replica chain overrides, a sequence
   inboxChains:
     - name: "alfajores"
-      disabled: false
       # -- The contract address for the replica contract
       address:
       domain:

--- a/typescript/infra/config/contexts.ts
+++ b/typescript/infra/config/contexts.ts
@@ -1,5 +1,0 @@
-// All valid deployment contexts. Environments may use just a subset of these contexts.
-export enum Contexts {
-  Abacus = 'abacus',
-  Flowcarbon = 'flowcarbon',
-}

--- a/typescript/infra/config/environments/dev/agent.ts
+++ b/typescript/infra/config/environments/dev/agent.ts
@@ -1,21 +1,17 @@
-import { ALL_KEY_ROLES } from '../../../src/agents/roles';
 import { AgentConfig } from '../../../src/config';
-import { Contexts } from '../../contexts';
 
 import { DevChains, chainNames } from './chains';
 import { validators } from './validators';
 
-export const abacus: AgentConfig<DevChains> = {
+export const agent: AgentConfig<DevChains> = {
   environment: 'dev',
   namespace: 'dev',
   runEnv: 'dev',
-  context: Contexts.Abacus,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
     tag: 'sha-5e639a2',
   },
-  environmentChainNames: chainNames,
-  contextChainNames: chainNames,
+  chainNames,
   validatorSets: validators,
   validator: {
     default: {
@@ -29,9 +25,15 @@ export const abacus: AgentConfig<DevChains> = {
       maxProcessingRetries: 10,
     },
   },
-  rolesWithKeys: ALL_KEY_ROLES,
-};
-
-export const agents = {
-  abacus,
+  kathy: {
+    default: {
+      enabled: false,
+      interval: 60 * 2,
+      chat: {
+        type: 'static',
+        message: '',
+        recipient: '',
+      },
+    },
+  },
 };

--- a/typescript/infra/config/environments/dev/index.ts
+++ b/typescript/infra/config/environments/dev/index.ts
@@ -1,8 +1,7 @@
 import { getMultiProviderFromGCP } from '../../../scripts/utils';
 import { CoreEnvironmentConfig } from '../../../src/config';
-import { Contexts } from '../../contexts';
 
-import { agents } from './agent';
+import { agent } from './agent';
 import { DevChains, devConfigs } from './chains';
 import { core } from './core';
 import { infrastructure } from './infrastructure';
@@ -10,9 +9,8 @@ import { infrastructure } from './infrastructure';
 export const environment: CoreEnvironmentConfig<DevChains> = {
   environment: 'dev',
   transactionConfigs: devConfigs,
-  getMultiProvider: (context?: Contexts) =>
-    getMultiProviderFromGCP(devConfigs, 'dev', context),
-  agents,
+  getMultiProvider: () => getMultiProviderFromGCP(devConfigs, 'dev'),
+  agent,
   core,
   infra: infrastructure,
 };

--- a/typescript/infra/config/environments/mainnet/agent.ts
+++ b/typescript/infra/config/environments/mainnet/agent.ts
@@ -1,15 +1,12 @@
-import { ALL_KEY_ROLES } from '../../../src/agents/roles';
 import { AgentConfig } from '../../../src/config';
-import { Contexts } from '../../contexts';
 
 import { MainnetChains, chainNames, environment } from './chains';
 import { validators } from './validators';
 
-export const abacus: AgentConfig<MainnetChains> = {
+export const agent: AgentConfig<MainnetChains> = {
   environment,
   namespace: environment,
   runEnv: environment,
-  context: Contexts.Abacus,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
     tag: 'sha-8740021',
@@ -17,8 +14,7 @@ export const abacus: AgentConfig<MainnetChains> = {
   aws: {
     region: 'us-east-1',
   },
-  environmentChainNames: chainNames,
-  contextChainNames: chainNames,
+  chainNames: chainNames,
   validatorSets: validators,
   validator: {
     default: {
@@ -55,9 +51,4 @@ export const abacus: AgentConfig<MainnetChains> = {
       maxProcessingRetries: 10,
     },
   },
-  rolesWithKeys: ALL_KEY_ROLES,
-};
-
-export const agents = {
-  abacus,
 };

--- a/typescript/infra/config/environments/mainnet/index.ts
+++ b/typescript/infra/config/environments/mainnet/index.ts
@@ -1,8 +1,7 @@
 import { getMultiProviderFromGCP } from '../../../scripts/utils';
 import { CoreEnvironmentConfig } from '../../../src/config';
-import { Contexts } from '../../contexts';
 
-import { agents } from './agent';
+import { agent } from './agent';
 import {
   MainnetChains,
   environment as environmentName,
@@ -16,9 +15,9 @@ import { infrastructure } from './infrastructure';
 export const environment: CoreEnvironmentConfig<MainnetChains> = {
   environment: environmentName,
   transactionConfigs: mainnetConfigs,
-  getMultiProvider: (context?: Contexts) =>
-    getMultiProviderFromGCP(mainnetConfigs, environmentName, context),
-  agents,
+  getMultiProvider: () =>
+    getMultiProviderFromGCP(mainnetConfigs, environmentName),
+  agent,
   core,
   infra: infrastructure,
   helloWorld,

--- a/typescript/infra/config/environments/test/agent.ts
+++ b/typescript/infra/config/environments/test/agent.ts
@@ -1,21 +1,17 @@
-import { ALL_KEY_ROLES } from '../../../src/agents/roles';
 import { AgentConfig } from '../../../src/config';
-import { Contexts } from '../../contexts';
 
 import { TestChains, chainNames } from './chains';
 import { validators } from './validators';
 
-export const abacus: AgentConfig<TestChains> = {
+export const agent: AgentConfig<TestChains> = {
   environment: 'test',
   namespace: 'test',
   runEnv: 'test',
-  context: Contexts.Abacus,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
     tag: '8852db3d88e87549269487da6da4ea5d67fdbfed',
   },
-  environmentChainNames: chainNames,
-  contextChainNames: chainNames,
+  chainNames,
   validatorSets: validators,
   validator: {
     default: {
@@ -29,9 +25,4 @@ export const abacus: AgentConfig<TestChains> = {
       maxProcessingRetries: 10,
     },
   },
-  rolesWithKeys: ALL_KEY_ROLES,
-};
-
-export const agents = {
-  abacus,
 };

--- a/typescript/infra/config/environments/test/index.ts
+++ b/typescript/infra/config/environments/test/index.ts
@@ -4,7 +4,7 @@ import { getMultiProviderFromConfigAndSigner } from '@abacus-network/sdk';
 
 import { CoreEnvironmentConfig } from '../../../src/config';
 
-import { agents } from './agent';
+import { agent } from './agent';
 import { TestChains, testConfigs } from './chains';
 import { core } from './core';
 import { infra } from './infra';
@@ -12,7 +12,7 @@ import { infra } from './infra';
 export const environment: CoreEnvironmentConfig<TestChains> = {
   environment: 'test',
   transactionConfigs: testConfigs,
-  agents,
+  agent,
   core,
   infra,
   // NOTE: Does not work from hardhat.config.ts

--- a/typescript/infra/config/environments/testnet/agent.ts
+++ b/typescript/infra/config/environments/testnet/agent.ts
@@ -1,15 +1,12 @@
-import { ALL_KEY_ROLES } from '../../../src/agents/roles';
 import { AgentConfig } from '../../../src/config';
-import { Contexts } from '../../contexts';
 
 import { TestnetChains, chainNames } from './chains';
 import { validators } from './validators';
 
-export const abacus: AgentConfig<TestnetChains> = {
+export const agent: AgentConfig<TestnetChains> = {
   environment: 'testnet',
   namespace: 'testnet',
   runEnv: 'testnet',
-  context: Contexts.Abacus,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
     tag: 'sha-5e639a2',
@@ -17,8 +14,7 @@ export const abacus: AgentConfig<TestnetChains> = {
   aws: {
     region: 'us-east-1',
   },
-  environmentChainNames: chainNames,
-  contextChainNames: chainNames,
+  chainNames: chainNames,
   validatorSets: validators,
   validator: {
     default: {
@@ -38,9 +34,15 @@ export const abacus: AgentConfig<TestnetChains> = {
       maxProcessingRetries: 10,
     },
   },
-  rolesWithKeys: ALL_KEY_ROLES,
-};
-
-export const agents = {
-  abacus,
+  // kathy: {
+  //   default: {
+  //     enabled: false,
+  //     interval: 60 * 2,
+  //     chat: {
+  //       type: 'static',
+  //       message: '',
+  //       recipient: '',
+  //     }
+  //   }
+  // }
 };

--- a/typescript/infra/config/environments/testnet/index.ts
+++ b/typescript/infra/config/environments/testnet/index.ts
@@ -1,8 +1,7 @@
 import { getMultiProviderFromGCP } from '../../../scripts/utils';
 import { CoreEnvironmentConfig } from '../../../src/config';
-import { Contexts } from '../../contexts';
 
-import { agents } from './agent';
+import { agent } from './agent';
 import { TestnetChains, testnetConfigs } from './chains';
 import { core } from './core';
 import { infrastructure } from './infrastructure';
@@ -10,9 +9,8 @@ import { infrastructure } from './infrastructure';
 export const environment: CoreEnvironmentConfig<TestnetChains> = {
   environment: 'testnet',
   transactionConfigs: testnetConfigs,
-  getMultiProvider: (context?: Contexts) =>
-    getMultiProviderFromGCP(testnetConfigs, 'testnet', context),
-  agents,
+  getMultiProvider: () => getMultiProviderFromGCP(testnetConfigs, 'testnet'),
+  agent,
   core,
   infra: infrastructure,
 };

--- a/typescript/infra/config/environments/testnet/infrastructure.ts
+++ b/typescript/infra/config/environments/testnet/infrastructure.ts
@@ -36,7 +36,6 @@ export const infrastructure: InfrastructureConfig = {
       'abacus-testnet-',
       'testnet-',
       'abacus-testnet2-',
-      'flowcarbon-testnet2-',
       'testnet2-',
     ],
   },

--- a/typescript/infra/config/environments/testnet2/agent.ts
+++ b/typescript/infra/config/environments/testnet2/agent.ts
@@ -1,15 +1,12 @@
-import { ALL_KEY_ROLES, KEY_ROLE_ENUM } from '../../../src/agents/roles';
 import { AgentConfig } from '../../../src/config';
-import { Contexts } from '../../contexts';
 
 import { TestnetChains, chainNames, environment } from './chains';
 import { validators } from './validators';
 
-export const abacus: AgentConfig<TestnetChains> = {
+export const agent: AgentConfig<TestnetChains> = {
   environment,
   namespace: environment,
   runEnv: environment,
-  context: Contexts.Abacus,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
     tag: 'sha-8740021',
@@ -17,8 +14,7 @@ export const abacus: AgentConfig<TestnetChains> = {
   aws: {
     region: 'us-east-1',
   },
-  environmentChainNames: chainNames,
-  contextChainNames: chainNames,
+  chainNames: chainNames,
   validatorSets: validators,
   validator: {
     default: {
@@ -55,43 +51,4 @@ export const abacus: AgentConfig<TestnetChains> = {
       maxProcessingRetries: 10,
     },
   },
-  rolesWithKeys: ALL_KEY_ROLES,
-};
-
-export const flowcarbon: AgentConfig<TestnetChains> = {
-  environment,
-  namespace: environment,
-  runEnv: environment,
-  context: Contexts.Flowcarbon,
-  docker: {
-    repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-8740021',
-  },
-  aws: {
-    region: 'us-east-1',
-  },
-  environmentChainNames: chainNames,
-  contextChainNames: ['alfajores', 'kovan'],
-  validatorSets: validators,
-  relayer: {
-    default: {
-      signedCheckpointPollingInterval: 5,
-      maxProcessingRetries: 10,
-      // Don't try to process any messages just yet
-      whitelist: [
-        {
-          sourceDomain: '1',
-          sourceAddress: '0x0000000000000000000000000000000000000000',
-          destinationDomain: '1',
-          destinationAddress: '0x0000000000000000000000000000000000000000',
-        },
-      ],
-    },
-  },
-  rolesWithKeys: [KEY_ROLE_ENUM.Relayer],
-};
-
-export const agents: Record<Contexts, AgentConfig<TestnetChains>> = {
-  abacus,
-  flowcarbon,
 };

--- a/typescript/infra/config/environments/testnet2/index.ts
+++ b/typescript/infra/config/environments/testnet2/index.ts
@@ -1,8 +1,7 @@
 import { getMultiProviderFromGCP } from '../../../scripts/utils';
 import { CoreEnvironmentConfig } from '../../../src/config';
-import { Contexts } from '../../contexts';
 
-import { agents } from './agent';
+import { agent } from './agent';
 import {
   TestnetChains,
   environment as environmentName,
@@ -16,9 +15,9 @@ import { infrastructure } from './infrastructure';
 export const environment: CoreEnvironmentConfig<TestnetChains> = {
   environment: environmentName,
   transactionConfigs: testnetConfigs,
-  getMultiProvider: (context?: Contexts) =>
-    getMultiProviderFromGCP(testnetConfigs, environmentName, context),
-  agents,
+  getMultiProvider: () =>
+    getMultiProviderFromGCP(testnetConfigs, environmentName),
+  agent,
   core,
   infra: infrastructure,
   helloWorld,

--- a/typescript/infra/config/environments/testnet2/infrastructure.ts
+++ b/typescript/infra/config/environments/testnet2/infrastructure.ts
@@ -36,7 +36,6 @@ export const infrastructure: InfrastructureConfig = {
       'abacus-testnet-',
       'testnet-',
       'abacus-testnet2-',
-      'flowcarbon-testnet2-',
       'testnet2-',
     ],
   },

--- a/typescript/infra/helm/relayer-funder/templates/cron-job.yaml
+++ b/typescript/infra/helm/relayer-funder/templates/cron-job.yaml
@@ -24,8 +24,6 @@ spec:
             - {{ .Values.abacus.runEnv }}
             - -f
             - /addresses-secret/addresses.json
-            - --context
-            - abacus
             env:
             - name: PROMETHEUS_PUSH_GATEWAY
               value: {{ .Values.infra.prometheusPushGateway }}

--- a/typescript/infra/scripts/create-keys.ts
+++ b/typescript/infra/scripts/create-keys.ts
@@ -1,10 +1,10 @@
 import { createAgentKeysIfNotExists } from '../src/agents/key-utils';
 
-import { getContextAgentConfig } from './utils';
+import { getEnvironmentConfig } from './utils';
 
 async function main() {
-  const agentConfig = await getContextAgentConfig();
-  return createAgentKeysIfNotExists(agentConfig);
+  const config = await getEnvironmentConfig();
+  return createAgentKeysIfNotExists(config.agent);
 }
 
 main().then(console.log).catch(console.error);

--- a/typescript/infra/scripts/delete-keys.ts
+++ b/typescript/infra/scripts/delete-keys.ts
@@ -1,10 +1,10 @@
 import { deleteAgentKeys } from '../src/agents/key-utils';
 
-import { getContextAgentConfig } from './utils';
+import { getEnvironmentConfig } from './utils';
 
 async function main() {
-  const agentConfig = await getContextAgentConfig();
-  return deleteAgentKeys(agentConfig);
+  const config = await getEnvironmentConfig();
+  return deleteAgentKeys(config.agent);
 }
 
 main().then(console.log).catch(console.error);

--- a/typescript/infra/scripts/deploy-agents.ts
+++ b/typescript/infra/scripts/deploy-agents.ts
@@ -1,18 +1,10 @@
 import { runAgentHelmCommand } from '../src/agents';
 import { HelmCommand } from '../src/utils/helm';
 
-import {
-  assertCorrectKubeContext,
-  getContextAgentConfig,
-  getCoreEnvironmentConfig,
-  getEnvironment,
-} from './utils';
+import { assertCorrectKubeContext, getEnvironmentConfig } from './utils';
 
 async function deploy() {
-  const environment = await getEnvironment();
-  const config = getCoreEnvironmentConfig(environment);
-
-  const agentConfig = await getContextAgentConfig(config);
+  const config = await getEnvironmentConfig();
 
   await assertCorrectKubeContext(config);
 
@@ -24,8 +16,8 @@ async function deploy() {
   // While this function still has these side effects, the workaround is to just
   // run the create-keys script first.
   await Promise.all(
-    agentConfig.contextChainNames.map((name: any) =>
-      runAgentHelmCommand(HelmCommand.InstallOrUpgrade, agentConfig, name),
+    config.agent.chainNames.map((name: any) =>
+      runAgentHelmCommand(HelmCommand.InstallOrUpgrade, config.agent, name),
     ),
   );
 }

--- a/typescript/infra/scripts/deploy-keymaster.ts
+++ b/typescript/infra/scripts/deploy-keymaster.ts
@@ -1,0 +1,11 @@
+import { runKeymasterHelmCommand } from '../src/agents';
+import { HelmCommand } from '../src/utils/helm';
+
+import { getEnvironmentConfig } from './utils';
+
+async function main() {
+  const config = await getEnvironmentConfig();
+  return runKeymasterHelmCommand(HelmCommand.InstallOrUpgrade, config.agent);
+}
+
+main().then(console.log).catch(console.error);

--- a/typescript/infra/scripts/funding/deploy-relayer-funder.ts
+++ b/typescript/infra/scripts/funding/deploy-relayer-funder.ts
@@ -1,27 +1,13 @@
-import {
-  getRelayerFunderConfig,
-  runRelayerFunderHelmCommand,
-} from '../../src/funding/deploy-relayer-funder';
+import { runRelayerFunderHelmCommand } from '../../src/funding/deploy-relayer-funder';
 import { HelmCommand } from '../../src/utils/helm';
-import {
-  assertCorrectKubeContext,
-  getContextAgentConfig,
-  getEnvironmentConfig,
-} from '../utils';
+import { assertCorrectKubeContext, getEnvironmentConfig } from '../utils';
 
 async function main() {
   const coreConfig = await getEnvironmentConfig();
 
   await assertCorrectKubeContext(coreConfig);
 
-  const relayerFunderConfig = getRelayerFunderConfig(coreConfig);
-  const agentConfig = await getContextAgentConfig(coreConfig);
-
-  await runRelayerFunderHelmCommand(
-    HelmCommand.InstallOrUpgrade,
-    agentConfig,
-    relayerFunderConfig,
-  );
+  await runRelayerFunderHelmCommand(HelmCommand.InstallOrUpgrade, coreConfig);
 }
 
 main()

--- a/typescript/infra/scripts/funding/fund-relayers-from-deployer.ts
+++ b/typescript/infra/scripts/funding/fund-relayers-from-deployer.ts
@@ -12,12 +12,7 @@ import { AgentKey, ReadOnlyAgentKey } from '../../src/agents/agent';
 import { getRelayerKeys } from '../../src/agents/key-utils';
 import { KEY_ROLE_ENUM } from '../../src/agents/roles';
 import { readJSONAtPath } from '../../src/utils/utils';
-import {
-  assertEnvironment,
-  getArgs,
-  getContextAgentConfig,
-  getCoreEnvironmentConfig,
-} from '../utils';
+import { assertEnvironment, getArgs, getCoreEnvironmentConfig } from '../utils';
 
 const constMetricLabels = {
   // this needs to get set in main because of async reasons
@@ -148,11 +143,10 @@ async function main() {
   constMetricLabels.abacus_deployment = environment;
   const config = getCoreEnvironmentConfig(environment);
   const multiProvider = await config.getMultiProvider();
-  const agentConfig = await getContextAgentConfig(config);
 
   const relayerKeys = argv.f
     ? getRelayerKeysFromSerializedAddressFile(argv.f)
-    : getRelayerKeys(agentConfig);
+    : getRelayerKeys(config.agent);
 
   const chains = relayerKeys.map((key) => key.chainName!);
   const balances: FunderBalance[] = [];

--- a/typescript/infra/scripts/get-key-addresses.ts
+++ b/typescript/infra/scripts/get-key-addresses.ts
@@ -1,11 +1,10 @@
 import { getAllKeys } from '../src/agents/key-utils';
 
-import { getContextAgentConfig } from './utils';
+import { getEnvironmentConfig } from './utils';
 
 async function main() {
-  const agentConfig = await getContextAgentConfig();
-
-  const keys = getAllKeys(agentConfig);
+  const config = await getEnvironmentConfig();
+  const keys = getAllKeys(config.agent);
 
   const keyInfos = await Promise.all(
     keys.map(async (key) => {

--- a/typescript/infra/scripts/helloworld/deploy-kathy.ts
+++ b/typescript/infra/scripts/helloworld/deploy-kathy.ts
@@ -1,26 +1,13 @@
 import { runHelloworldKathyHelmCommand } from '../../src/helloworld/kathy';
 import { HelmCommand } from '../../src/utils/helm';
-import {
-  assertCorrectKubeContext,
-  getContextAgentConfig,
-  getEnvironmentConfig,
-} from '../utils';
-
-import { getHelloWorldConfig } from './utils';
+import { assertCorrectKubeContext, getEnvironmentConfig } from '../utils';
 
 async function main() {
   const coreConfig = await getEnvironmentConfig();
 
   await assertCorrectKubeContext(coreConfig);
 
-  const agentConfig = await getContextAgentConfig(coreConfig);
-  const kathyConfig = getHelloWorldConfig(coreConfig).kathy;
-
-  await runHelloworldKathyHelmCommand(
-    HelmCommand.InstallOrUpgrade,
-    agentConfig,
-    kathyConfig,
-  );
+  await runHelloworldKathyHelmCommand(HelmCommand.InstallOrUpgrade, coreConfig);
 }
 
 main()

--- a/typescript/infra/scripts/output-agent-env-vars.ts
+++ b/typescript/infra/scripts/output-agent-env-vars.ts
@@ -1,7 +1,11 @@
 import { getAgentEnvVars } from '../src/agents';
 import { writeFile } from 'fs/promises';
 
-import { getContextAgentConfig, getKeyRoleAndChainArgs } from './utils';
+import {
+  getCoreEnvironmentConfig,
+  getEnvironment,
+  getKeyRoleAndChainArgs,
+} from './utils';
 
 async function main() {
   const argv = await getKeyRoleAndChainArgs()
@@ -10,11 +14,12 @@ async function main() {
     .describe('f', 'filepath')
     .require('f').argv;
 
-  const agentConfig = await getContextAgentConfig();
+  const environment = await getEnvironment();
+  const config = getCoreEnvironmentConfig(environment);
   const envVars = await getAgentEnvVars<any>(
     argv.c,
     argv.r,
-    agentConfig,
+    config.agent,
     argv.i,
   );
 

--- a/typescript/infra/scripts/rotate-key.ts
+++ b/typescript/infra/scripts/rotate-key.ts
@@ -1,5 +1,5 @@
 import {
-  getContextAgentConfig,
+  getCoreEnvironmentConfig,
   getEnvironment,
   getKeyRoleAndChainArgs,
 } from './utils';
@@ -9,13 +9,13 @@ async function rotateKey() {
   const argv = await args.argv;
 
   const environment = await getEnvironment();
-  const agentConfig = await getContextAgentConfig();
+  const config = getCoreEnvironmentConfig(environment);
 
   switch (environment) {
     // TODO: re-implement this when the environments actually get readded
     case 'test': {
       console.log("I don't do anything");
-      console.log(argv, agentConfig);
+      console.log(argv, config.agent);
     }
     // case DeployEnvironment.dev: {
     //   await rotateGCPKey(environment, argv.r, argv.c);

--- a/typescript/infra/scripts/update-agents-diff.ts
+++ b/typescript/infra/scripts/update-agents-diff.ts
@@ -1,23 +1,17 @@
 import { runAgentHelmCommand } from '../src/agents';
 import { HelmCommand } from '../src/utils/helm';
 
-import {
-  assertCorrectKubeContext,
-  getContextAgentConfig,
-  getCoreEnvironmentConfig,
-  getEnvironment,
-} from './utils';
+import { getCoreEnvironmentConfig, getEnvironment } from './utils';
 
 async function deploy() {
   const environment = await getEnvironment();
-
   const config = getCoreEnvironmentConfig(environment);
-  await assertCorrectKubeContext(config);
-
-  const agentConfig = await getContextAgentConfig(config);
-
-  for (const chain of agentConfig.contextChainNames) {
-    await runAgentHelmCommand<any>(HelmCommand.UpgradeDiff, agentConfig, chain);
+  for (const chain of config.agent.chainNames) {
+    await runAgentHelmCommand<any>(
+      HelmCommand.UpgradeDiff,
+      config.agent,
+      chain,
+    );
   }
 }
 

--- a/typescript/infra/scripts/update-key.ts
+++ b/typescript/infra/scripts/update-key.ts
@@ -1,5 +1,5 @@
 import {
-  getContextAgentConfig,
+  getCoreEnvironmentConfig,
   getEnvironment,
   getKeyRoleAndChainArgs,
 } from './utils';
@@ -9,13 +9,13 @@ async function rotateKey() {
   const argv = await args.argv;
 
   const environment = await getEnvironment();
-  const agentConfig = await getContextAgentConfig();
+  const config = getCoreEnvironmentConfig(environment);
 
   switch (environment) {
     // TODO: Reimplement this when the environments get readded
     case 'test': {
       console.log("I don't do anything");
-      console.log(argv, agentConfig);
+      console.log(argv, config.agent);
     }
     // case DeployEnvironment.testnet:
     // case DeployEnvironment.mainnet:

--- a/typescript/infra/scripts/utils.ts
+++ b/typescript/infra/scripts/utils.ts
@@ -10,7 +10,6 @@ import {
 } from '@abacus-network/sdk';
 import { objMap, promiseObjAll } from '@abacus-network/sdk/dist/utils';
 
-import { Contexts } from '../config/contexts';
 import { environments } from '../config/environments';
 import { getCurrentKubernetesContext } from '../src/agents';
 import { KEY_ROLE_ENUM } from '../src/agents/roles';
@@ -24,8 +23,6 @@ export function getArgs() {
     .alias('e', 'env')
     .describe('e', 'deploy environment')
     .string('e')
-    .describe('context', 'deploy context')
-    .string('context')
     .help('h')
     .alias('h', 'help');
 }
@@ -58,57 +55,14 @@ export async function getEnvironmentConfig() {
   return getCoreEnvironmentConfig(await getEnvironment());
 }
 
-export function assertContext(contextStr: string): Contexts {
-  const context = contextStr as Contexts;
-  if (Object.values(Contexts).includes(context)) {
-    return context;
-  }
-  throw new Error(
-    `Invalid context ${contextStr}, must be one of ${Object.values(
-      Contexts,
-    )}. ${
-      contextStr === undefined ? ' Did you specify --context <context>?' : ''
-    }`,
-  );
-}
-
-export async function getContext(): Promise<Contexts> {
-  const argv = await getArgs().argv;
-  return assertContext(argv.context!);
-}
-
-export async function getContextAgentConfig<Chain extends ChainName>(
-  coreEnvironmentConfig?: CoreEnvironmentConfig<Chain>,
-) {
-  const coreConfig = coreEnvironmentConfig
-    ? coreEnvironmentConfig
-    : await getEnvironmentConfig();
-  const context = await getContext();
-  const agentConfig = coreConfig.agents[context];
-  if (!agentConfig) {
-    throw Error(
-      `Invalid context ${context} for environment, must be one of ${Object.keys(
-        coreConfig.agents,
-      )}.`,
-    );
-  }
-  return agentConfig;
-}
-
 export async function getMultiProviderFromGCP<Chain extends ChainName>(
   txConfigs: ChainMap<Chain, IChainConnection>,
   environment: DeployEnvironment,
-  context?: Contexts,
 ) {
   const connections = await promiseObjAll(
     objMap(txConfigs, async (chain, config) => {
       const provider = await fetchProvider(environment, chain);
-      const signer = await fetchSigner(
-        environment,
-        context ?? Contexts.Abacus,
-        chain,
-        provider,
-      );
+      const signer = await fetchSigner(environment, chain, provider);
       return {
         ...config,
         provider,
@@ -166,7 +120,7 @@ export async function assertCorrectKubeContext<Chain extends ChainName>(
     !currentKubeContext.endsWith(`${coreConfig.infra.kubernetes.clusterName}`)
   ) {
     console.error(
-      `Cowardly refusing to deploy using k8s context ${currentKubeContext}; are you sure you have the right k8s context active?`,
+      `Cowardly refusing to deploy ${coreConfig.agent.runEnv} to ${currentKubeContext}; are you sure you have the right k8s context active?`,
     );
     process.exit(1);
   }

--- a/typescript/infra/src/agents/agent.ts
+++ b/typescript/infra/src/agents/agent.ts
@@ -1,7 +1,5 @@
 import { ChainName } from '@abacus-network/sdk';
 
-import { Contexts } from '../../config/contexts';
-import { assertContext } from '../../scripts/utils';
 import { assertChain, assertRole } from '../utils/utils';
 
 import { KEY_ROLE_ENUM } from './roles';
@@ -9,7 +7,6 @@ import { KEY_ROLE_ENUM } from './roles';
 export abstract class AgentKey {
   constructor(
     public environment: string,
-    public context: Contexts,
     public readonly role: KEY_ROLE_ENUM,
     public readonly chainName?: ChainName,
     public readonly index?: number,
@@ -39,14 +36,13 @@ export class ReadOnlyAgentKey extends AgentKey {
 
   constructor(
     public environment: string,
-    public context: Contexts,
     public readonly role: KEY_ROLE_ENUM,
     identifier: string,
     address: string,
     public readonly chainName?: ChainName,
     public readonly index?: number,
   ) {
-    super(environment, context, role, chainName, index);
+    super(environment, role, chainName, index);
 
     this._identifier = identifier;
     this._address = address;
@@ -57,11 +53,10 @@ export class ReadOnlyAgentKey extends AgentKey {
    * and constructs a ReadOnlyAgentKey.
    * @param identifier The "identifier" of the key. This can come in a few different
    * flavors, e.g.:
-   * alias/abacus-testnet2-key-kathy (<-- abacus context, not specific to any chain)
-   * alias/abacus-testnet2-key-optimismkovan-relayer (<-- abacus context, chain specific)
-   * alias/abacus-testnet2-key-alfajores-validator-0 (<-- abacus context, chain specific and has an index)
+   * alias/abacus-testnet2-key-kathy (<-- not specific to any chain)
+   * alias/abacus-testnet2-key-optimismkovan-relayer (<-- chain specific)
+   * alias/abacus-testnet2-key-alfajores-validator-0 (<-- chain specific and has an index)
    * abacus-dev-key-kathy (<-- same idea as above, but without the `alias/` prefix if it's not AWS-based)
-   * alias/flowcarbon-testnet2-key-optimismkovan-relayer (<-- flowcarbon context & chain specific, intended to show that there are non-abacus contexts)
    * @param address The address of the key.
    * @returns A ReadOnlyAgentKey for the provided identifier and address.
    */
@@ -70,43 +65,39 @@ export class ReadOnlyAgentKey extends AgentKey {
     address: string,
   ): ReadOnlyAgentKey {
     const regex =
-      /.*([a-zA-Z0-9]+)-([a-zA-Z0-9]+)-key-([a-zA-Z0-9]+)-?([a-zA-Z0-9]+)?-?([0-9]+)?/g;
+      /.*abacus-([a-zA-Z0-9]+)-key-([a-zA-Z0-9]+)-?([a-zA-Z0-9]+)?-?([0-9]+)?/g;
     const matches = regex.exec(identifier);
     if (!matches) {
       throw Error('Invalid identifier');
     }
-    const context = assertContext(matches[1]);
-    const environment = matches[2];
+    const environment = matches[1];
 
-    // If matches[4] is undefined, this key doesn't have a chainName, and matches[3]
+    // If matches[3] is undefined, this key doesn't have a chainName, and matches[2]
     // is the role name.
-    if (matches[4] === undefined) {
+    if (matches[3] === undefined) {
       return new ReadOnlyAgentKey(
         environment,
-        context,
-        assertRole(matches[3]),
+        assertRole(matches[2]),
         identifier,
         address,
       );
-    } else if (matches[5] === undefined) {
-      // If matches[5] is undefined, this key doesn't have an index.
+    } else if (matches[4] === undefined) {
+      // If matches[4] is undefined, this key doesn't have an index.
       return new ReadOnlyAgentKey(
         environment,
-        context,
-        assertRole(matches[4]),
+        assertRole(matches[3]),
         identifier,
         address,
-        assertChain(matches[3]),
+        assertChain(matches[2]),
       );
     } else {
       return new ReadOnlyAgentKey(
         environment,
-        context,
-        assertRole(matches[4]),
+        assertRole(matches[3]),
         identifier,
         address,
-        assertChain(matches[3]),
-        parseInt(matches[5]),
+        assertChain(matches[2]),
+        parseInt(matches[4]),
       );
     }
   }
@@ -143,12 +134,11 @@ export function isValidatorKey(role: string) {
 function identifier(
   isKey: boolean,
   environment: string,
-  context: Contexts,
   role: string,
   chainName?: ChainName,
   index?: number,
 ) {
-  const prefix = `${context}-${environment}-${isKey ? 'key-' : ''}`;
+  const prefix = `abacus-${environment}-${isKey ? 'key-' : ''}`;
   switch (role) {
     case KEY_ROLE_ENUM.Validator:
       if (index === undefined) {
@@ -167,20 +157,18 @@ function identifier(
 
 export function keyIdentifier(
   environment: string,
-  context: Contexts,
   role: string,
   chainName?: ChainName,
   index?: number,
 ) {
-  return identifier(true, environment, context, role, chainName, index);
+  return identifier(true, environment, role, chainName, index);
 }
 
 export function userIdentifier(
   environment: string,
-  context: Contexts,
   role: string,
   chainName?: ChainName,
   index?: number,
 ) {
-  return identifier(false, environment, context, role, chainName, index);
+  return identifier(false, environment, role, chainName, index);
 }

--- a/typescript/infra/src/agents/aws/key.ts
+++ b/typescript/infra/src/agents/aws/key.ts
@@ -43,7 +43,7 @@ export class AgentAwsKey extends AgentKey {
     chainName?: ChainName,
     index?: number,
   ) {
-    super(agentConfig.environment, agentConfig.context, role, chainName, index);
+    super(agentConfig.environment, role, chainName, index);
     if (!agentConfig.aws) {
       throw new Error('Not configured as AWS');
     }
@@ -63,7 +63,6 @@ export class AgentAwsKey extends AgentKey {
   get identifier() {
     return `alias/${keyIdentifier(
       this.environment,
-      this.context,
       this.role,
       this.chainName,
       this.index,

--- a/typescript/infra/src/agents/aws/user.ts
+++ b/typescript/infra/src/agents/aws/user.ts
@@ -3,13 +3,10 @@ import {
   CreateUserCommand,
   IAMClient,
   ListUsersCommand,
-  ListUsersCommandOutput,
-  User,
 } from '@aws-sdk/client-iam';
 
 import { ChainName } from '@abacus-network/sdk';
 
-import { Contexts } from '../../../config/contexts';
 import { AgentConfig } from '../../config';
 import {
   fetchGCPSecret,
@@ -28,7 +25,6 @@ export class AgentAwsUser<Chain extends ChainName> {
 
   constructor(
     public readonly environment: string,
-    public readonly context: Contexts,
     public readonly chainName: Chain,
     public readonly role: KEY_ROLE_ENUM,
     public readonly region: string,
@@ -40,8 +36,9 @@ export class AgentAwsUser<Chain extends ChainName> {
   // Gets API access keys and saves them in GCP secret manager if they do not already exist.
   // Populates `this._arn` with the ARN of the user.
   async createIfNotExists() {
-    const users = await this.getUsers();
-    const match = users.find((user) => user.UserName === this.userName);
+    const cmd = new ListUsersCommand({});
+    const result = await this.adminIamClient.send(cmd);
+    const match = result.Users?.find((user) => user.UserName === this.userName);
     if (match) {
       this._arn = match?.Arn;
     } else {
@@ -117,33 +114,6 @@ export class AgentAwsUser<Chain extends ChainName> {
     return key;
   }
 
-  private async getUsers(): Promise<User[]> {
-    let users: User[] = [];
-    let marker: string | undefined = undefined;
-    // List will output a max of 100 at a time, so we need to use marker
-    // to fetch all of them.
-    while (true) {
-      const listAliasResponse: ListUsersCommandOutput =
-        await this.adminIamClient.send(
-          new ListUsersCommand({
-            Marker: marker,
-          }),
-        );
-      if (!listAliasResponse.Users || listAliasResponse.Users.length === 0) {
-        break;
-      }
-
-      users = users.concat(listAliasResponse.Users);
-
-      if (listAliasResponse.IsTruncated) {
-        marker = listAliasResponse.Marker;
-      } else {
-        break;
-      }
-    }
-    return users;
-  }
-
   get awsTags() {
     const tags = this.tags;
     return Object.keys(tags).map((key) => ({
@@ -161,12 +131,7 @@ export class AgentAwsUser<Chain extends ChainName> {
   }
 
   get userName() {
-    return userIdentifier(
-      this.environment,
-      this.context,
-      this.role,
-      this.chainName,
-    );
+    return userIdentifier(this.environment, this.role, this.chainName);
   }
 
   get accessKeyIdSecretName() {

--- a/typescript/infra/src/agents/aws/validator-user.ts
+++ b/typescript/infra/src/agents/aws/validator-user.ts
@@ -7,7 +7,6 @@ import {
 
 import { ChainName } from '@abacus-network/sdk';
 
-import { Contexts } from '../../../config/contexts';
 import { AgentConfig } from '../../config';
 import { KEY_ROLE_ENUM } from '../roles';
 
@@ -21,13 +20,12 @@ export class ValidatorAgentAwsUser<
 
   constructor(
     environment: string,
-    context: Contexts,
     chainName: Chain,
     public readonly index: number,
     region: string,
     public readonly bucket: string,
   ) {
-    super(environment, context, chainName, KEY_ROLE_ENUM.Validator, region);
+    super(environment, chainName, KEY_ROLE_ENUM.Validator, region);
     this.adminS3Client = new S3Client({ region });
   }
 
@@ -99,6 +97,6 @@ export class ValidatorAgentAwsUser<
   }
 
   get userName() {
-    return `${this.context}-${this.environment}-${this.chainName}-${this.role}-${this.index}`;
+    return `abacus-${this.environment}-${this.chainName}-${this.role}-${this.index}`;
   }
 }

--- a/typescript/infra/src/agents/gcp.ts
+++ b/typescript/infra/src/agents/gcp.ts
@@ -2,7 +2,6 @@ import { Wallet } from 'ethers';
 
 import { ChainName } from '@abacus-network/sdk';
 
-import { Contexts } from '../../config/contexts';
 import { fetchGCPSecret, setGCPSecret } from '../utils/gcloud';
 import { execCmd, include } from '../utils/utils';
 
@@ -35,13 +34,12 @@ type RemoteKey = UnfetchedKey | FetchedKey;
 export class AgentGCPKey extends AgentKey {
   constructor(
     environment: string,
-    context: Contexts,
     role: KEY_ROLE_ENUM,
     chainName?: ChainName,
     index?: number,
     private remoteKey: RemoteKey = { fetched: false },
   ) {
-    super(environment, context, role, chainName, index);
+    super(environment, role, chainName, index);
   }
 
   async createIfNotExists() {
@@ -68,7 +66,6 @@ export class AgentGCPKey extends AgentKey {
   get identifier() {
     return keyIdentifier(
       this.environment,
-      this.context,
       this.role,
       this.chainName,
       this.index,
@@ -128,14 +125,12 @@ export class AgentGCPKey extends AgentKey {
       JSON.stringify({
         role: this.role,
         environment: this.environment,
-        context: this.context,
         privateKey: wallet.privateKey,
         address,
         ...include(this.isValidatorKey, { chainName: this.chainName }),
       }),
       {
         environment: this.environment,
-        context: this.context,
         role: this.role,
         ...include(this.isValidatorKey, {
           chain: this.chainName,

--- a/typescript/infra/src/agents/index.ts
+++ b/typescript/infra/src/agents/index.ts
@@ -1,18 +1,18 @@
 import { ChainName } from '@abacus-network/sdk';
 
-import { Contexts } from '../../config/contexts';
 import { AgentConfig, DeployEnvironment } from '../config';
 import { ChainAgentConfig, CheckpointSyncerType } from '../config/agent';
 import { fetchGCPSecret } from '../utils/gcloud';
 import { HelmCommand, helmifyValues } from '../utils/helm';
-import { execCmd, strip0x } from '../utils/utils';
+import { ensure0x, execCmd, strip0x } from '../utils/utils';
+import { rm, writeFile } from 'fs/promises';
 
 import { keyIdentifier } from './agent';
 import { AgentAwsUser, ValidatorAgentAwsUser } from './aws';
 import { AgentAwsKey } from './aws/key';
 import { AgentGCPKey } from './gcp';
 import { fetchKeysForChain } from './key-utils';
-import { KEY_ROLE_ENUM } from './roles';
+import { KEY_ROLES, KEY_ROLE_ENUM } from './roles';
 
 async function helmValuesForChain<Chain extends ChainName>(
   chainName: Chain,
@@ -27,26 +27,24 @@ async function helmValuesForChain<Chain extends ChainName>(
     },
     abacus: {
       runEnv: agentConfig.runEnv,
-      context: agentConfig.context,
       baseConfig: `${chainName}_config.json`,
       outboxChain: {
         name: chainName,
       },
       aws: !!agentConfig.aws,
-      inboxChains: agentConfig.environmentChainNames
+      inboxChains: agentConfig.chainNames
         .filter((name) => name !== chainName)
         .map((remoteChainName) => {
           return {
             name: remoteChainName,
-            disabled: !agentConfig.contextChainNames.includes(remoteChainName),
           };
         }),
       validator: {
-        enabled: chainAgentConfig.validatorEnabled,
+        enabled: true,
         configs: await chainAgentConfig.validatorConfigs(),
       },
       relayer: {
-        enabled: chainAgentConfig.relayerEnabled,
+        enabled: true,
         aws: await chainAgentConfig.relayerRequiresAwsCredentials(),
         signers: await chainAgentConfig.relayerSigners(),
         config: chainAgentConfig.relayerConfig,
@@ -67,7 +65,7 @@ export async function getAgentEnvVars<Chain extends ChainName>(
   agentConfig: AgentConfig<Chain>,
   index?: number,
 ) {
-  const chainNames = agentConfig.contextChainNames;
+  const chainNames = agentConfig.chainNames;
   if (role === KEY_ROLE_ENUM.Validator && index === undefined) {
     throw Error('Expected index for validator role');
   }
@@ -106,7 +104,6 @@ export async function getAgentEnvVars<Chain extends ChainName>(
 
     const keyId = keyIdentifier(
       agentConfig.environment,
-      agentConfig.context,
       role,
       outboxChainName,
       index,
@@ -146,7 +143,6 @@ export async function getAgentEnvVars<Chain extends ChainName>(
       }
       user = new ValidatorAgentAwsUser(
         agentConfig.environment,
-        agentConfig.context,
         outboxChainName,
         index!,
         checkpointSyncer.region,
@@ -155,7 +151,6 @@ export async function getAgentEnvVars<Chain extends ChainName>(
     } else {
       user = new AgentAwsUser(
         agentConfig.environment,
-        agentConfig.context,
         outboxChainName,
         role,
         agentConfig.aws!.region,
@@ -184,21 +179,17 @@ export async function getAgentEnvVars<Chain extends ChainName>(
 
   switch (role) {
     case KEY_ROLE_ENUM.Validator:
-      if (valueDict.abacus.validator.configs) {
-        envVars = envVars.concat(
-          configEnvVars(
-            valueDict.abacus.validator.configs[index!],
-            KEY_ROLE_ENUM.Validator,
-          ),
-        );
-      }
+      envVars = envVars.concat(
+        configEnvVars(
+          valueDict.abacus.validator.configs[index!],
+          KEY_ROLE_ENUM.Validator,
+        ),
+      );
       break;
     case KEY_ROLE_ENUM.Relayer:
-      if (valueDict.abacus.relayer.config) {
-        envVars = envVars.concat(
-          configEnvVars(valueDict.abacus.relayer.config, KEY_ROLE_ENUM.Relayer),
-        );
-      }
+      envVars = envVars.concat(
+        configEnvVars(valueDict.abacus.relayer.config, KEY_ROLE_ENUM.Relayer),
+      );
       break;
     case KEY_ROLE_ENUM.Kathy:
       if (valueDict.abacus.kathy.config) {
@@ -267,15 +258,9 @@ export async function getSecretRpcEndpoint(
 
 export async function getSecretDeployerKey(
   environment: DeployEnvironment,
-  context: Contexts,
   chainName: ChainName,
 ) {
-  const key = new AgentGCPKey(
-    environment,
-    context,
-    KEY_ROLE_ENUM.Deployer,
-    chainName,
-  );
+  const key = new AgentGCPKey(environment, KEY_ROLE_ENUM.Deployer, chainName);
   await key.fetch();
   return key.privateKey;
 }
@@ -285,7 +270,7 @@ async function getSecretRpcEndpoints<Chain extends ChainName>(
 ) {
   const environment = agentConfig.runEnv;
   return getSecretForEachChain(
-    agentConfig.contextChainNames,
+    agentConfig.chainNames,
     (name: ChainName) => `${environment}-rpc-endpoint-${name}`,
     false,
   );
@@ -324,10 +309,7 @@ export async function runAgentHelmCommand<Chain extends ChainName>(
       : '';
 
   return execCmd(
-    `helm ${action} ${getHelmReleaseName(
-      outboxChainName,
-      agentConfig,
-    )} ../../rust/helm/abacus-agent/ --create-namespace --namespace ${
+    `helm ${action} ${outboxChainName} ../../rust/helm/abacus-agent/ --create-namespace --namespace ${
       agentConfig.namespace
     } ${values.join(' ')} ${extraPipe}`,
     {},
@@ -336,16 +318,68 @@ export async function runAgentHelmCommand<Chain extends ChainName>(
   );
 }
 
-function getHelmReleaseName<Chain extends ChainName>(
-  outboxChainName: Chain,
-  agentConfig: AgentConfig<Chain>,
-): string {
-  // For backward compatibility reasons, don't include the context
-  // in the name of the helm release if the context is the default "abacus"
-  if (agentConfig.context === 'abacus') {
-    return outboxChainName;
-  }
-  return `${outboxChainName}-${agentConfig.context}`;
+export async function runKeymasterHelmCommand(
+  action: HelmCommand,
+  agentConfig: AgentConfig<any>,
+) {
+  const chainNames = agentConfig.chainNames;
+  // It's ok to use pick an arbitrary chain here since we are only grabbing the signers
+  const chainName = chainNames[0];
+  const gcpKeys = (await fetchKeysForChain(agentConfig, chainName)) as Record<
+    string,
+    AgentGCPKey
+  >;
+  const bankKey = gcpKeys[KEY_ROLE_ENUM.Bank];
+  const config = {
+    networks: Object.fromEntries(
+      await Promise.all(
+        chainNames.map(async (name) => {
+          return [
+            name,
+            {
+              endpoint: await getSecretRpcEndpoint(
+                agentConfig.environment,
+                name,
+              ),
+              bank: {
+                signer: ensure0x(bankKey.privateKey),
+                address: bankKey.address,
+              },
+              threshold: 200000000000000000,
+            },
+          ];
+        }),
+      ),
+    ),
+    homes: Object.fromEntries(
+      chainNames.map((name) => {
+        return [
+          name,
+          {
+            replicas: chainNames,
+            addresses: Object.fromEntries(
+              KEY_ROLES.filter((_) => _.endsWith('signer')).map((role) => [
+                role,
+                gcpKeys[role].address,
+              ]),
+            ),
+          },
+        ];
+      }),
+    ),
+  };
+
+  await writeFile(`config.json`, JSON.stringify(config));
+
+  await execCmd(
+    `helm ${action} keymaster-${agentConfig.environment} ../../tools/keymaster/helm/keymaster/ --namespace ${agentConfig.namespace} --set-file keymaster.config=config.json`,
+    {},
+    false,
+    true,
+  );
+
+  await rm('config.json');
+  return;
 }
 
 export async function getCurrentKubernetesContext(): Promise<string> {

--- a/typescript/infra/src/agents/roles.ts
+++ b/typescript/infra/src/agents/roles.ts
@@ -6,7 +6,7 @@ export enum KEY_ROLE_ENUM {
   Kathy = 'kathy',
 }
 
-export const ALL_KEY_ROLES = [
+export const KEY_ROLES = [
   KEY_ROLE_ENUM.Validator,
   KEY_ROLE_ENUM.Relayer,
   KEY_ROLE_ENUM.Deployer,

--- a/typescript/infra/src/config/chain.ts
+++ b/typescript/infra/src/config/chain.ts
@@ -5,7 +5,6 @@ import { ethers } from 'ethers';
 import { StaticCeloJsonRpcProvider } from '@abacus-network/celo-ethers-provider';
 import { ChainName, RetryJsonRpcProvider } from '@abacus-network/sdk';
 
-import { Contexts } from '../../config/contexts';
 import { getSecretDeployerKey, getSecretRpcEndpoint } from '../agents';
 
 import { DeployEnvironment } from './environment';
@@ -27,11 +26,10 @@ export async function fetchProvider(
 
 export async function fetchSigner(
   environment: DeployEnvironment,
-  context: Contexts,
   chainName: ChainName,
   provider: Provider,
 ) {
-  const key = await getSecretDeployerKey(environment, context, chainName);
+  const key = await getSecretDeployerKey(environment, chainName);
   const wallet = new ethers.Wallet(key, provider);
   return new NonceManager(wallet);
 }

--- a/typescript/infra/src/config/environment.ts
+++ b/typescript/infra/src/config/environment.ts
@@ -6,7 +6,6 @@ import {
   MultiProvider,
 } from '@abacus-network/sdk';
 
-import { Contexts } from '../../config/contexts';
 import { environments } from '../../config/environments';
 
 import { AgentConfig } from './agent';
@@ -24,11 +23,10 @@ export type EnvironmentChain<E extends DeployEnvironment> = Extract<
 export type CoreEnvironmentConfig<Chain extends ChainName> = {
   environment: DeployEnvironment;
   transactionConfigs: EnvironmentConfig<Chain>;
-  // Each AgentConfig, keyed by the context
-  agents: Partial<Record<Contexts, AgentConfig<Chain>>>;
+  agent: AgentConfig<Chain>;
   core: ChainMap<Chain, CoreConfig>;
   infra: InfrastructureConfig;
-  getMultiProvider: (context?: Contexts) => Promise<MultiProvider<Chain>>;
+  getMultiProvider: () => Promise<MultiProvider<Chain>>;
   helloWorld?: HelloWorldConfig<Chain>;
   relayerFunderConfig?: RelayerFunderConfig;
 };

--- a/typescript/infra/src/funding/deploy-relayer-funder.ts
+++ b/typescript/infra/src/funding/deploy-relayer-funder.ts
@@ -1,16 +1,16 @@
 import { ChainName } from '@abacus-network/sdk';
 
-import { AgentConfig, CoreEnvironmentConfig } from '../config';
+import { CoreEnvironmentConfig } from '../config';
 import { RelayerFunderConfig } from '../config/funding';
 import { HelmCommand, helmifyValues } from '../utils/helm';
 import { execCmd } from '../utils/utils';
 
 export function runRelayerFunderHelmCommand<Chain extends ChainName>(
   helmCommand: HelmCommand,
-  agentConfig: AgentConfig<Chain>,
-  relayerFunderConfig: RelayerFunderConfig,
+  coreConfig: CoreEnvironmentConfig<Chain>,
 ) {
-  const values = getRelayerFunderHelmValues(agentConfig, relayerFunderConfig);
+  const relayerFunderConfig = getRelayerFunderConfig(coreConfig);
+  const values = getRelayerFunderHelmValues(coreConfig, relayerFunderConfig);
 
   return execCmd(
     `helm ${helmCommand} relayer-funder ./helm/relayer-funder --namespace ${
@@ -20,7 +20,7 @@ export function runRelayerFunderHelmCommand<Chain extends ChainName>(
 }
 
 function getRelayerFunderHelmValues<Chain extends ChainName>(
-  agentConfig: AgentConfig<Chain>,
+  coreConfig: CoreEnvironmentConfig<Chain>,
   relayerFunderConfig: RelayerFunderConfig,
 ) {
   const values = {
@@ -28,8 +28,8 @@ function getRelayerFunderHelmValues<Chain extends ChainName>(
       schedule: relayerFunderConfig.cronSchedule,
     },
     abacus: {
-      runEnv: agentConfig.environment,
-      chains: agentConfig.contextChainNames,
+      runEnv: coreConfig.environment,
+      chains: coreConfig.agent.chainNames,
     },
     image: {
       repository: relayerFunderConfig.docker.repo,

--- a/typescript/infra/src/helloworld/kathy.ts
+++ b/typescript/infra/src/helloworld/kathy.ts
@@ -1,16 +1,17 @@
 import { ChainName } from '@abacus-network/sdk';
 
-import { AgentConfig } from '../config';
+import { getHelloWorldConfig } from '../../scripts/helloworld/utils';
+import { CoreEnvironmentConfig } from '../config';
 import { HelloWorldKathyConfig } from '../config/helloworld';
 import { HelmCommand, helmifyValues } from '../utils/helm';
 import { execCmd } from '../utils/utils';
 
 export function runHelloworldKathyHelmCommand<Chain extends ChainName>(
   helmCommand: HelmCommand,
-  agentConfig: AgentConfig<Chain>,
-  kathyConfig: HelloWorldKathyConfig<Chain>,
+  coreConfig: CoreEnvironmentConfig<Chain>,
 ) {
-  const values = getHelloworldKathyHelmValues(agentConfig, kathyConfig);
+  const kathyConfig = getHelloWorldConfig(coreConfig).kathy;
+  const values = getHelloworldKathyHelmValues(coreConfig, kathyConfig);
 
   return execCmd(
     `helm ${helmCommand} helloworld-kathy ./helm/helloworld-kathy --namespace ${
@@ -20,7 +21,7 @@ export function runHelloworldKathyHelmCommand<Chain extends ChainName>(
 }
 
 function getHelloworldKathyHelmValues<Chain extends ChainName>(
-  agentConfig: AgentConfig<Chain>,
+  coreConfig: CoreEnvironmentConfig<Chain>,
   kathyConfig: HelloWorldKathyConfig<Chain>,
 ) {
   const values = {
@@ -34,7 +35,7 @@ function getHelloworldKathyHelmValues<Chain extends ChainName>(
       // the list of chains that kathy will send to. Because Kathy
       // will fetch secrets for all chains, regardless of skipping them or
       // not, we pass in all chains
-      chains: agentConfig.contextChainNames,
+      chains: coreConfig.agent.chainNames,
     },
     image: {
       repository: kathyConfig.docker.repo,

--- a/typescript/infra/src/utils/helm.ts
+++ b/typescript/infra/src/utils/helm.ts
@@ -12,12 +12,7 @@ export enum HelmCommand {
 
 export function helmifyValues(config: any, prefix?: string): string[] {
   if (typeof config !== 'object') {
-    // Helm incorrectly splits on unescaped commas.
-    const value =
-      config !== undefined
-        ? JSON.stringify(config).replaceAll(',', '\\,')
-        : undefined;
-    return [`--set ${prefix}=${value}`];
+    return [`--set ${prefix}=${JSON.stringify(config)}`];
   }
 
   if (config.flatMap) {

--- a/typescript/infra/src/utils/utils.ts
+++ b/typescript/infra/src/utils/utils.ts
@@ -7,7 +7,7 @@ import path from 'path';
 
 import { AllChains, ChainName } from '@abacus-network/sdk';
 
-import { ALL_KEY_ROLES, KEY_ROLE_ENUM } from '../agents/roles';
+import { KEY_ROLES, KEY_ROLE_ENUM } from '../agents/roles';
 
 export function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -181,7 +181,7 @@ export function readJSONAtPath(filepath: string) {
 
 export function assertRole(roleStr: string) {
   const role = roleStr as KEY_ROLE_ENUM;
-  if (!ALL_KEY_ROLES.includes(role)) {
+  if (!KEY_ROLES.includes(role)) {
     throw Error(`Invalid role ${role}`);
   }
   return role;


### PR DESCRIPTION
This reverts commit e4a2811176cf92be83f88711d70e559f905ac6ec.

Apparently there's a circular dependency that is manifesting bizarrely when running `infra` scripts. Reverting this fixed it, tomorrow I'll investigate where exactly the circular dependency is. I think it may be from bringing out the `enum Contexts` to a higher level that's now used in a bunch of places. Very annoying that CI / a `yarn build` or something doesn't catch this