### PR TITLE
Add origin domain check to Inbox.process()

### DIFF
--- a/solidity/core/contracts/Inbox.sol
+++ b/solidity/core/contracts/Inbox.sol
@@ -130,6 +130,8 @@ contract Inbox is IInbox, ReentrancyGuardUpgradeable, Version0, Mailbox {
             bytes calldata body
         ) = _message.destructure();
 
+        // ensure message came from the correct domain
+        require(origin == remoteDomain, "!origin");
         // ensure message was meant for this domain
         require(destination == localDomain, "!destination");
 

--- a/solidity/core/test/inbox.test.ts
+++ b/solidity/core/test/inbox.test.ts
@@ -169,6 +169,30 @@ describe('Inbox', async () => {
     });
   }
 
+  it('Fails to process message with wrong origin Domain', async () => {
+    const outboxFactory = new TestOutbox__factory(signer);
+    const originOutbox = await outboxFactory.deploy(localDomain + 1);
+    await originOutbox.initialize(validatorManager.address);
+
+    const proof = await dispatchMessageAndReturnProof(
+      originOutbox,
+      localDomain,
+      recipient,
+      'hello world',
+    );
+
+    await expect(
+      validatorManager.process(
+        inbox.address,
+        proof.root,
+        proof.index,
+        proof.message,
+        proof.proof,
+        proof.index,
+      ),
+    ).to.be.revertedWith('!origin');
+  });
+
   it('Fails to process message with wrong destination Domain', async () => {
     const badProof = await dispatchMessageAndReturnProof(
       helperOutbox,


### PR DESCRIPTION
This check prevents a byzantine validator set from spoofing messages from a different origin domain.

Fixes #736 