### PR TITLE
docs: Fix typo in validator.rs

### DIFF
--- a/rust/agents/validator/src/validator.rs
+++ b/rust/agents/validator/src/validator.rs
@@ -11,7 +11,7 @@ use eyre::Result;
 use crate::submit::ValidatorSubmitterMetrics;
 use crate::{settings::ValidatorSettings as Settings, submit::ValidatorSubmitter};
 
-/// An validator agent
+/// A validator agent
 #[derive(Debug)]
 pub struct Validator {
     signer: Arc<Signers>,


### PR DESCRIPTION
Fixes a small typo in the user-facing documentation