### PR TITLE
Set reorgPeriod / finalityBlocks for arbitrum and optimism to 0 for testnet2 and mainnet

### DIFF
--- a/rust/config/mainnet/arbitrum_config.json
+++ b/rust/config/mainnet/arbitrum_config.json
@@ -62,7 +62,7 @@
       "domain": "28528",
       "name": "optimism",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""
@@ -94,7 +94,7 @@
     "domain": "6386274",
     "name": "arbitrum",
     "rpcStyle": "ethereum",
-    "finalityBlocks": "1",
+    "finalityBlocks": "0",
     "connection": {
       "type": "http",
       "url": ""

--- a/rust/config/mainnet/avalanche_config.json
+++ b/rust/config/mainnet/avalanche_config.json
@@ -48,7 +48,7 @@
       "domain": "6386274",
       "name": "arbitrum",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""
@@ -62,7 +62,7 @@
       "domain": "28528",
       "name": "optimism",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""

--- a/rust/config/mainnet/bsc_config.json
+++ b/rust/config/mainnet/bsc_config.json
@@ -48,7 +48,7 @@
       "domain": "6386274",
       "name": "arbitrum",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""
@@ -62,7 +62,7 @@
       "domain": "28528",
       "name": "optimism",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""

--- a/rust/config/mainnet/celo_config.json
+++ b/rust/config/mainnet/celo_config.json
@@ -48,7 +48,7 @@
       "domain": "6386274",
       "name": "arbitrum",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""
@@ -62,7 +62,7 @@
       "domain": "28528",
       "name": "optimism",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""

--- a/rust/config/mainnet/ethereum_config.json
+++ b/rust/config/mainnet/ethereum_config.json
@@ -62,7 +62,7 @@
       "domain": "6386274",
       "name": "arbitrum",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""
@@ -76,7 +76,7 @@
       "domain": "28528",
       "name": "optimism",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""

--- a/rust/config/mainnet/optimism_config.json
+++ b/rust/config/mainnet/optimism_config.json
@@ -62,7 +62,7 @@
       "domain": "6386274",
       "name": "arbitrum",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""
@@ -94,7 +94,7 @@
     "domain": "28528",
     "name": "optimism",
     "rpcStyle": "ethereum",
-    "finalityBlocks": "1",
+    "finalityBlocks": "0",
     "connection": {
       "type": "http",
       "url": ""

--- a/rust/config/mainnet/polygon_config.json
+++ b/rust/config/mainnet/polygon_config.json
@@ -48,7 +48,7 @@
       "domain": "6386274",
       "name": "arbitrum",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""
@@ -62,7 +62,7 @@
       "domain": "28528",
       "name": "optimism",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""

--- a/rust/config/testnet2/alfajores_config.json
+++ b/rust/config/testnet2/alfajores_config.json
@@ -62,7 +62,7 @@
       "domain": "1634872690",
       "name": "arbitrumrinkeby",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""
@@ -76,7 +76,7 @@
       "domain": "1869622635",
       "name": "optimismkovan",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""

--- a/rust/config/testnet2/arbitrumrinkeby_config.json
+++ b/rust/config/testnet2/arbitrumrinkeby_config.json
@@ -76,7 +76,7 @@
       "domain": "1869622635",
       "name": "optimismkovan",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""
@@ -94,7 +94,7 @@
     "domain": "1634872690",
     "name": "arbitrumrinkeby",
     "rpcStyle": "ethereum",
-    "finalityBlocks": "1",
+    "finalityBlocks": "0",
     "connection": {
       "type": "http",
       "url": ""

--- a/rust/config/testnet2/bsctestnet_config.json
+++ b/rust/config/testnet2/bsctestnet_config.json
@@ -62,7 +62,7 @@
       "domain": "1634872690",
       "name": "arbitrumrinkeby",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""
@@ -76,7 +76,7 @@
       "domain": "1869622635",
       "name": "optimismkovan",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""

--- a/rust/config/testnet2/fuji_config.json
+++ b/rust/config/testnet2/fuji_config.json
@@ -62,7 +62,7 @@
       "domain": "1634872690",
       "name": "arbitrumrinkeby",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""
@@ -76,7 +76,7 @@
       "domain": "1869622635",
       "name": "optimismkovan",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""

--- a/rust/config/testnet2/kovan_config.json
+++ b/rust/config/testnet2/kovan_config.json
@@ -62,7 +62,7 @@
       "domain": "1634872690",
       "name": "arbitrumrinkeby",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""
@@ -76,7 +76,7 @@
       "domain": "1869622635",
       "name": "optimismkovan",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""

--- a/rust/config/testnet2/mumbai_config.json
+++ b/rust/config/testnet2/mumbai_config.json
@@ -62,7 +62,7 @@
       "domain": "1634872690",
       "name": "arbitrumrinkeby",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""
@@ -76,7 +76,7 @@
       "domain": "1869622635",
       "name": "optimismkovan",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""

--- a/rust/config/testnet2/optimismkovan_config.json
+++ b/rust/config/testnet2/optimismkovan_config.json
@@ -76,7 +76,7 @@
       "domain": "1634872690",
       "name": "arbitrumrinkeby",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""
@@ -94,7 +94,7 @@
     "domain": "1869622635",
     "name": "optimismkovan",
     "rpcStyle": "ethereum",
-    "finalityBlocks": "1",
+    "finalityBlocks": "0",
     "connection": {
       "type": "http",
       "url": ""

--- a/typescript/infra/config/environments/mainnet/agent.ts
+++ b/typescript/infra/config/environments/mainnet/agent.ts
@@ -36,10 +36,10 @@ export const abacus: AgentConfig<MainnetChains> = {
         reorgPeriod: 15,
       },
       optimism: {
-        reorgPeriod: 20,
+        reorgPeriod: 0,
       },
       arbitrum: {
-        reorgPeriod: 1,
+        reorgPeriod: 0,
       },
       avalanche: {
         reorgPeriod: 1,

--- a/typescript/infra/config/environments/mainnet/core/rust/arbitrum_config.json
+++ b/typescript/infra/config/environments/mainnet/core/rust/arbitrum_config.json
@@ -62,7 +62,7 @@
       "domain": "28528",
       "name": "optimism",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""
@@ -76,7 +76,7 @@
       "domain": "6648936",
       "name": "ethereum",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "15",
+      "finalityBlocks": "20",
       "connection": {
         "type": "http",
         "url": ""
@@ -94,7 +94,7 @@
     "domain": "6386274",
     "name": "arbitrum",
     "rpcStyle": "ethereum",
-    "finalityBlocks": "1",
+    "finalityBlocks": "0",
     "connection": {
       "type": "http",
       "url": ""

--- a/typescript/infra/config/environments/mainnet/core/rust/avalanche_config.json
+++ b/typescript/infra/config/environments/mainnet/core/rust/avalanche_config.json
@@ -48,7 +48,7 @@
       "domain": "6386274",
       "name": "arbitrum",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""
@@ -62,7 +62,7 @@
       "domain": "28528",
       "name": "optimism",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""
@@ -76,7 +76,7 @@
       "domain": "6648936",
       "name": "ethereum",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "15",
+      "finalityBlocks": "20",
       "connection": {
         "type": "http",
         "url": ""

--- a/typescript/infra/config/environments/mainnet/core/rust/bsc_config.json
+++ b/typescript/infra/config/environments/mainnet/core/rust/bsc_config.json
@@ -48,7 +48,7 @@
       "domain": "6386274",
       "name": "arbitrum",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""
@@ -62,7 +62,7 @@
       "domain": "28528",
       "name": "optimism",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""
@@ -76,7 +76,7 @@
       "domain": "6648936",
       "name": "ethereum",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "15",
+      "finalityBlocks": "20",
       "connection": {
         "type": "http",
         "url": ""

--- a/typescript/infra/config/environments/mainnet/core/rust/celo_config.json
+++ b/typescript/infra/config/environments/mainnet/core/rust/celo_config.json
@@ -48,7 +48,7 @@
       "domain": "6386274",
       "name": "arbitrum",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""
@@ -62,7 +62,7 @@
       "domain": "28528",
       "name": "optimism",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""
@@ -76,7 +76,7 @@
       "domain": "6648936",
       "name": "ethereum",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "15",
+      "finalityBlocks": "20",
       "connection": {
         "type": "http",
         "url": ""

--- a/typescript/infra/config/environments/mainnet/core/rust/ethereum_config.json
+++ b/typescript/infra/config/environments/mainnet/core/rust/ethereum_config.json
@@ -62,7 +62,7 @@
       "domain": "6386274",
       "name": "arbitrum",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""
@@ -76,7 +76,7 @@
       "domain": "28528",
       "name": "optimism",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""
@@ -94,7 +94,7 @@
     "domain": "6648936",
     "name": "ethereum",
     "rpcStyle": "ethereum",
-    "finalityBlocks": "15",
+    "finalityBlocks": "20",
     "connection": {
       "type": "http",
       "url": ""

--- a/typescript/infra/config/environments/mainnet/core/rust/optimism_config.json
+++ b/typescript/infra/config/environments/mainnet/core/rust/optimism_config.json
@@ -62,7 +62,7 @@
       "domain": "6386274",
       "name": "arbitrum",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""
@@ -76,7 +76,7 @@
       "domain": "6648936",
       "name": "ethereum",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "15",
+      "finalityBlocks": "20",
       "connection": {
         "type": "http",
         "url": ""
@@ -94,7 +94,7 @@
     "domain": "28528",
     "name": "optimism",
     "rpcStyle": "ethereum",
-    "finalityBlocks": "1",
+    "finalityBlocks": "0",
     "connection": {
       "type": "http",
       "url": ""

--- a/typescript/infra/config/environments/mainnet/core/rust/polygon_config.json
+++ b/typescript/infra/config/environments/mainnet/core/rust/polygon_config.json
@@ -48,7 +48,7 @@
       "domain": "6386274",
       "name": "arbitrum",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""
@@ -62,7 +62,7 @@
       "domain": "28528",
       "name": "optimism",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""
@@ -76,7 +76,7 @@
       "domain": "6648936",
       "name": "ethereum",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "15",
+      "finalityBlocks": "20",
       "connection": {
         "type": "http",
         "url": ""

--- a/typescript/infra/config/environments/testnet/agent.ts
+++ b/typescript/infra/config/environments/testnet/agent.ts
@@ -28,7 +28,11 @@ export const abacus: AgentConfig<TestnetChains> = {
     chainOverrides: {
       optimismkovan: {
         interval: 5,
-        reorgPeriod: 2,
+        reorgPeriod: 0,
+      },
+      arbitrumrinkeby: {
+        interval: 5,
+        reorgPeriod: 0,
       },
     },
   },

--- a/typescript/infra/config/environments/testnet2/agent.ts
+++ b/typescript/infra/config/environments/testnet2/agent.ts
@@ -42,10 +42,10 @@ export const abacus: AgentConfig<TestnetChains> = {
         reorgPeriod: 9,
       },
       arbitrumrinkeby: {
-        reorgPeriod: 1,
+        reorgPeriod: 0,
       },
       optimismkovan: {
-        reorgPeriod: 1,
+        reorgPeriod: 0,
       },
     },
   },

--- a/typescript/infra/config/environments/testnet2/core/rust/alfajores_config.json
+++ b/typescript/infra/config/environments/testnet2/core/rust/alfajores_config.json
@@ -62,7 +62,7 @@
       "domain": "1634872690",
       "name": "arbitrumrinkeby",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""
@@ -76,7 +76,7 @@
       "domain": "1869622635",
       "name": "optimismkovan",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""

--- a/typescript/infra/config/environments/testnet2/core/rust/arbitrumrinkeby_config.json
+++ b/typescript/infra/config/environments/testnet2/core/rust/arbitrumrinkeby_config.json
@@ -76,7 +76,7 @@
       "domain": "1869622635",
       "name": "optimismkovan",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""
@@ -94,7 +94,7 @@
     "domain": "1634872690",
     "name": "arbitrumrinkeby",
     "rpcStyle": "ethereum",
-    "finalityBlocks": "1",
+    "finalityBlocks": "0",
     "connection": {
       "type": "http",
       "url": ""

--- a/typescript/infra/config/environments/testnet2/core/rust/bsctestnet_config.json
+++ b/typescript/infra/config/environments/testnet2/core/rust/bsctestnet_config.json
@@ -62,7 +62,7 @@
       "domain": "1634872690",
       "name": "arbitrumrinkeby",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""
@@ -76,7 +76,7 @@
       "domain": "1869622635",
       "name": "optimismkovan",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""

--- a/typescript/infra/config/environments/testnet2/core/rust/fuji_config.json
+++ b/typescript/infra/config/environments/testnet2/core/rust/fuji_config.json
@@ -62,7 +62,7 @@
       "domain": "1634872690",
       "name": "arbitrumrinkeby",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""
@@ -76,7 +76,7 @@
       "domain": "1869622635",
       "name": "optimismkovan",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""

--- a/typescript/infra/config/environments/testnet2/core/rust/kovan_config.json
+++ b/typescript/infra/config/environments/testnet2/core/rust/kovan_config.json
@@ -62,7 +62,7 @@
       "domain": "1634872690",
       "name": "arbitrumrinkeby",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""
@@ -76,7 +76,7 @@
       "domain": "1869622635",
       "name": "optimismkovan",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""

--- a/typescript/infra/config/environments/testnet2/core/rust/mumbai_config.json
+++ b/typescript/infra/config/environments/testnet2/core/rust/mumbai_config.json
@@ -62,7 +62,7 @@
       "domain": "1634872690",
       "name": "arbitrumrinkeby",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""
@@ -76,7 +76,7 @@
       "domain": "1869622635",
       "name": "optimismkovan",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""

--- a/typescript/infra/config/environments/testnet2/core/rust/optimismkovan_config.json
+++ b/typescript/infra/config/environments/testnet2/core/rust/optimismkovan_config.json
@@ -76,7 +76,7 @@
       "domain": "1634872690",
       "name": "arbitrumrinkeby",
       "rpcStyle": "ethereum",
-      "finalityBlocks": "1",
+      "finalityBlocks": "0",
       "connection": {
         "type": "http",
         "url": ""
@@ -94,7 +94,7 @@
     "domain": "1869622635",
     "name": "optimismkovan",
     "rpcStyle": "ethereum",
-    "finalityBlocks": "1",
+    "finalityBlocks": "0",
     "connection": {
       "type": "http",
       "url": ""

--- a/typescript/sdk/src/consts/chainMetadata.ts
+++ b/typescript/sdk/src/consts/chainMetadata.ts
@@ -37,12 +37,12 @@ export const ethereum: ChainMetadata = {
 
 export const arbitrum: ChainMetadata = {
   id: 0x617262, // b'arb' interpreted as an int
-  finalityBlocks: 1,
+  finalityBlocks: 0,
 };
 
 export const optimism: ChainMetadata = {
   id: 0x6f70, // b'op' interpreted as an int
-  finalityBlocks: 1,
+  finalityBlocks: 0,
 };
 
 export const bsc: ChainMetadata = {
@@ -125,12 +125,12 @@ export const bsctestnet: ChainMetadata = {
 
 export const arbitrumrinkeby: ChainMetadata = {
   id: 0x61722d72, // b'ar-r' interpreted as an int
-  finalityBlocks: 1,
+  finalityBlocks: 0,
 };
 
 export const optimismkovan: ChainMetadata = {
   id: 0x6f702d6b, // b'op-k' interpreted as an int
-  finalityBlocks: 1,
+  finalityBlocks: 0,
 };
 
 export const auroratestnet: ChainMetadata = {


### PR DESCRIPTION
Coming out of Nam's research in https://github.com/abacus-network/abacus-monorepo/issues/596#issuecomment-1172263027, this sets the arbitrum and optimism reorg periods to 0 for mainnet and testnet2.

I know this is a lot of files changed for what's materially a very small change -- note we have #532 to track consolidating reorgPeriod & finalityBlocks. We should consider removing the rust configs in `typescript/infra/config/environments/**/*` altogether by having the SDK just write them directly to the `rust/config` dir, which I've created an issue for: https://github.com/abacus-network/abacus-monorepo/issues/779

Doing this because I'm observing more arbitrum RPC issues where we're trying an `eth_call` at a specific height due to the lag logic in the validator, but for some reason the RPC provider is unable to read state at the requested block height. Because of https://github.com/abacus-network/abacus-monorepo/pull/676, we will request the `"latest"` block for `eth_call`s that have a lag of zero, so this should allow us to avoid any future issues with arbitrum / optimism