### PR TITLE
cleanup: Drop vestigial references to the optics project.

### DIFF
--- a/rust/abacus-core/src/lib.rs
+++ b/rust/abacus-core/src/lib.rs
@@ -1,5 +1,3 @@
-//! Abacus. OPTimistic Interchain Communication
-//!
 //! This crate contains core primitives, traits, and types for Abacus
 //! implementations.
 

--- a/rust/abacus-test/src/lib.rs
+++ b/rust/abacus-test/src/lib.rs
@@ -1,5 +1,3 @@
-//! Abacus. OPTimistic Interchain Communication
-//!
 //! This crate contains mocks and utilities for testing Abacus agents.
 
 #![forbid(unsafe_code)]


### PR DESCRIPTION
Lingering in just a couple of comments.