### PR TITLE
Make timeout longer for contract deploy

### DIFF
--- a/rust/utils/run-locally/src/main.rs
+++ b/rust/utils/run-locally/src/main.rs
@@ -230,7 +230,7 @@ fn main() -> ExitCode {
     // }
     state.node = Some(node);
 
-    sleep(Duration::from_secs(5));
+    sleep(Duration::from_secs(10));
 
     println!("Deploying abacus contracts...");
     let status = Command::new("yarn")


### PR DESCRIPTION
At @webbhorn's suggestion, I was able to repo locally by setting a very short timeout, so using a much longer one should help here.

Closes #801 