### PR TITLE
Increase kathy gas, adjust relayer funder cadence

### DIFF
--- a/typescript/helloworld/src/app/app.ts
+++ b/typescript/helloworld/src/app/app.ts
@@ -32,7 +32,7 @@ export class HelloWorldApp<
       message,
       chainConnection.overrides,
     );
-    const gasLimit = estimated.mul(11).div(10);
+    const gasLimit = estimated.mul(12).div(10);
 
     const tx = await sender.sendHelloWorld(toDomain, message, {
       ...chainConnection.overrides,

--- a/typescript/infra/config/environments/mainnet/funding.ts
+++ b/typescript/infra/config/environments/mainnet/funding.ts
@@ -7,7 +7,7 @@ export const relayerFunderConfig: RelayerFunderConfig = {
     repo: 'gcr.io/abacus-labs-dev/abacus-monorepo',
     tag: 'sha-63f7341',
   },
-  cronSchedule: '*/10 * * * *', // Every 10 minutes
+  cronSchedule: '45 * * * *', // Every hour at the 45 minute mark
   namespace: environment,
   prometheusPushGateway:
     'http://prometheus-pushgateway.monitoring.svc.cluster.local:9091',


### PR DESCRIPTION
This PR makes two small changes to address alerts that have fired in the last day.

First, it adjusts Kathy gas estimation to increase the multiplier from 1.1 times the estimate to 1.2. We had a Kathy tx last night that ran out of gas.

Second, it adjusts the relayer funder to run every hour at the 45 minute mark, rather than every 10 minutes, so as not to conflict with Kathy, per https://github.com/abacus-network/abacus-monorepo/issues/780