### PR TITLE
Update mumbai gas prices

### DIFF
--- a/typescript/infra/config/environments/testnet2/chains.ts
+++ b/typescript/infra/config/environments/testnet2/chains.ts
@@ -4,7 +4,13 @@ export const testnetConfigs = {
   alfajores: chainConnectionConfigs.alfajores,
   kovan: chainConnectionConfigs.kovan,
   fuji: chainConnectionConfigs.fuji,
-  mumbai: chainConnectionConfigs.mumbai,
+  mumbai: {
+    ...chainConnectionConfigs.mumbai,
+    overrides: {
+      maxFeePerGas: 100 * 10 ** 9, // 100 gwei
+      maxPriorityFeePerGas: 40 * 10 ** 9, // 40 gwei
+    },
+  },
   bsctestnet: chainConnectionConfigs.bsctestnet,
   arbitrumrinkeby: chainConnectionConfigs.arbitrumrinkeby,
   optimismkovan: chainConnectionConfigs.optimismkovan,


### PR DESCRIPTION
We've been defaulting to 1.5gwei for maxFeePerGas which is underpriced, preventing us from submitting txs to mumbai.