### PR TITLE
set instant finality to 1 confirmation

### DIFF
--- a/typescript/sdk/src/consts/chainConnectionConfigs.ts
+++ b/typescript/sdk/src/consts/chainConnectionConfigs.ts
@@ -70,7 +70,7 @@ export const alfajores: IChainConnection = {
     'https://alfajores-forno.celo-testnet.org',
     44787,
   ),
-  confirmations: 0,
+  confirmations: 1,
   blockExplorerUrl: 'https://alfajores-blockscout.celo-testnet.org/',
 };
 


### PR DESCRIPTION
Ethers will interptet 0 confirmations as an excuse to treat a null confirmation as valid https://github.com/ethers-io/ethers.js/blob/master/packages/providers/src.ts/base-provider.ts#L1286

This PR thus treats instant finality as 1 confirmation, not 0 confirmations