### PR TITLE
Bypass `NonceManager` in `getMultiProviderFromGCP`

### DIFF
--- a/typescript/infra/src/config/chain.ts
+++ b/typescript/infra/src/config/chain.ts
@@ -31,7 +31,5 @@ export async function fetchSigner(
   provider: Provider,
 ) {
   const key = await getSecretDeployerKey(environment, context, chainName);
-  const wallet = new ethers.Wallet(key, provider);
-  return wallet;
-  // return new NonceManager(wallet);
+  return new ethers.Wallet(key, provider);
 }

--- a/typescript/infra/src/config/chain.ts
+++ b/typescript/infra/src/config/chain.ts
@@ -1,5 +1,4 @@
 import { Provider } from '@ethersproject/abstract-provider';
-import { NonceManager } from '@ethersproject/experimental';
 import { ethers } from 'ethers';
 
 import { StaticCeloJsonRpcProvider } from '@abacus-network/celo-ethers-provider';
@@ -33,5 +32,6 @@ export async function fetchSigner(
 ) {
   const key = await getSecretDeployerKey(environment, context, chainName);
   const wallet = new ethers.Wallet(key, provider);
-  return new NonceManager(wallet);
+  return wallet;
+  // return new NonceManager(wallet);
 }


### PR DESCRIPTION
> [9:39 AM] tkporter: My theory is we:
> 1. signed a tx using the NonceManager, which locally increments the nonce N to N+1 that it'll use for the next tx signing
> 2. had a provider issue like the rlp one that caused the previously signed tx to never be mined
> 3. kathy just continues on to the next message to do
> 4. when we eventually want to send a message from arbitrumrinkeby again, we sign the tx with the nonce N+1, leaving a gap

> [9:41 AM] tkporter: all the nonce too high logs have the tx nonce incrementing so this is probably it