### PR TITLE
Deploy kathy / key funder without nonce manager

### DIFF
--- a/typescript/infra/config/environments/mainnet/funding.ts
+++ b/typescript/infra/config/environments/mainnet/funding.ts
@@ -7,7 +7,7 @@ import { environment } from './chains';
 export const keyFunderConfig: KeyFunderConfig = {
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-monorepo',
-    tag: 'sha-51b594b',
+    tag: 'sha-936afa7',
   },
   cronSchedule: '45 * * * *', // Every hour at the 45 minute mark
   namespace: environment,

--- a/typescript/infra/config/environments/testnet2/funding.ts
+++ b/typescript/infra/config/environments/testnet2/funding.ts
@@ -7,7 +7,7 @@ import { environment } from './chains';
 export const keyFunderConfig: KeyFunderConfig = {
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-monorepo',
-    tag: 'sha-51b594b',
+    tag: 'sha-936afa7',
   },
   cronSchedule: '45 * * * *', // Every hour at the 45 minute mark
   namespace: environment,

--- a/typescript/infra/config/environments/testnet2/helloworld.ts
+++ b/typescript/infra/config/environments/testnet2/helloworld.ts
@@ -8,7 +8,7 @@ export const helloWorld: HelloWorldConfig<TestnetChains> = {
   kathy: {
     docker: {
       repo: 'gcr.io/abacus-labs-dev/abacus-monorepo',
-      tag: 'sha-1f62484',
+      tag: 'sha-936afa7',
     },
     chainsToSkip: [],
     runEnv: environment,


### PR DESCRIPTION
* Deploys testnet2 kathy, and testnet2 & mainnet key funder to include #888
* Not deploying kathy on mainnet yet as we've not transitioned mainnet kathy to being a service yet