### PR TITLE
Fund kathy keys in testnet2 & mainnet, fix some issues with Kathy infra and InterchainGasCalculator

### DIFF
--- a/typescript/infra/config/environments/mainnet/funding.ts
+++ b/typescript/infra/config/environments/mainnet/funding.ts
@@ -15,6 +15,6 @@ export const keyFunderConfig: KeyFunderConfig = {
     'http://prometheus-pushgateway.monitoring.svc.cluster.local:9091',
   contextFundingFrom: Contexts.Abacus,
   contextsAndRolesToFund: {
-    [Contexts.Abacus]: [KEY_ROLE_ENUM.Relayer],
+    [Contexts.Abacus]: [KEY_ROLE_ENUM.Relayer, KEY_ROLE_ENUM.Kathy],
   },
 };

--- a/typescript/infra/config/environments/mainnet/helloworld.ts
+++ b/typescript/infra/config/environments/mainnet/helloworld.ts
@@ -8,7 +8,7 @@ export const helloWorld: HelloWorldConfig<MainnetChains> = {
   kathy: {
     docker: {
       repo: 'gcr.io/abacus-labs-dev/abacus-monorepo',
-      tag: 'sha-f0c45a1',
+      tag: 'sha-936afa7',
     },
     chainsToSkip: [],
     runEnv: environment,

--- a/typescript/infra/config/environments/testnet2/funding.ts
+++ b/typescript/infra/config/environments/testnet2/funding.ts
@@ -15,6 +15,6 @@ export const keyFunderConfig: KeyFunderConfig = {
     'http://prometheus-pushgateway.monitoring.svc.cluster.local:9091',
   contextFundingFrom: Contexts.Abacus,
   contextsAndRolesToFund: {
-    [Contexts.Abacus]: [KEY_ROLE_ENUM.Relayer],
+    [Contexts.Abacus]: [KEY_ROLE_ENUM.Relayer, KEY_ROLE_ENUM.Kathy],
   },
 };

--- a/typescript/infra/config/environments/testnet2/helloworld.ts
+++ b/typescript/infra/config/environments/testnet2/helloworld.ts
@@ -8,7 +8,7 @@ export const helloWorld: HelloWorldConfig<TestnetChains> = {
   kathy: {
     docker: {
       repo: 'gcr.io/abacus-labs-dev/abacus-monorepo',
-      tag: 'sha-8be723e',
+      tag: 'sha-ba68a1d',
     },
     chainsToSkip: [],
     runEnv: environment,

--- a/typescript/infra/config/environments/testnet2/helloworld.ts
+++ b/typescript/infra/config/environments/testnet2/helloworld.ts
@@ -8,7 +8,7 @@ export const helloWorld: HelloWorldConfig<TestnetChains> = {
   kathy: {
     docker: {
       repo: 'gcr.io/abacus-labs-dev/abacus-monorepo',
-      tag: 'sha-936afa7',
+      tag: 'sha-8be723e',
     },
     chainsToSkip: [],
     runEnv: environment,

--- a/typescript/infra/helm/helloworld-kathy/templates/stateful-set.yaml
+++ b/typescript/infra/helm/helloworld-kathy/templates/stateful-set.yaml
@@ -28,6 +28,8 @@ spec:
         - ./typescript/infra/scripts/helloworld/kathy.ts
         - -e
         - {{ .Values.abacus.runEnv }}
+        - --context
+        - {{ .Values.abacus.context }}
         envFrom:
         - secretRef:
             name: helloworld-kathy-secret

--- a/typescript/infra/helm/key-funder/templates/cron-job.yaml
+++ b/typescript/infra/helm/key-funder/templates/cron-job.yaml
@@ -24,7 +24,7 @@ spec:
             - {{ .Values.abacus.runEnv }}
             - --context
             - {{ .Values.abacus.contextFundingFrom }}
-{{- range $context, $roles := .Values.abacus.contextsAndRoles }}
+{{- range $context, $roles := .Values.abacus.contextsAndRolesToFund }}
             - --contexts-and-roles
             - {{ $context }}={{ join "," $roles }}
             - -f

--- a/typescript/infra/helm/key-funder/values.yaml
+++ b/typescript/infra/helm/key-funder/values.yaml
@@ -7,7 +7,7 @@ abacus:
   chains: []
   contextFundingFrom: abacus
   # key = context, value = array of roles to fund
-  contextsAndRoles:
+  contextsAndRolesToFund:
     abacus:
     - relayer
 cronjob:

--- a/typescript/infra/scripts/helloworld/kathy.ts
+++ b/typescript/infra/scripts/helloworld/kathy.ts
@@ -104,7 +104,7 @@ async function main() {
     .filter((v) => v !== null)
     .map((v) => v!);
 
-  debug('Parings calculated', { chains, pairings });
+  debug('Pairings calculated', { chains, pairings });
 
   // track how many we are still allowed to send in case some messages send slower than expected.
   let allowedToSend = 1;

--- a/typescript/sdk/src/gas/calculator.test.ts
+++ b/typescript/sdk/src/gas/calculator.test.ts
@@ -69,8 +69,8 @@ describe('InterchainGasCalculator', () => {
 
   beforeEach(() => {
     tokenPriceGetter = new MockTokenPriceGetter();
-    tokenPriceGetter.setTokenPrice(origin, 10);
-    tokenPriceGetter.setTokenPrice(destination, 5);
+    tokenPriceGetter.setTokenPrice(origin, 9.0909);
+    tokenPriceGetter.setTokenPrice(destination, 5.5);
     calculator = new TestInterchainGasCalculator(multiProvider, core, {
       tokenPriceGetter,
       // A multiplier of 1 makes testing easier to reason about
@@ -97,8 +97,8 @@ describe('InterchainGasCalculator', () => {
         BigNumber.from(HANDLE_GAS),
       );
 
-      // 100k gas * 10 gas price * ($5 per destination token / $10 per origin token)
-      expect(estimatedPayment.toNumber()).to.equal(500_000);
+      // 100k gas * 10 gas price * ($5.5 per destination token / $9.0909 per origin token)
+      expect(estimatedPayment.toNumber()).to.equal(605_000);
     });
   });
 
@@ -122,8 +122,8 @@ describe('InterchainGasCalculator', () => {
       );
 
       // (100_000 dest handler gas + 100_000 process overhead gas)
-      // * 10 gas price * ($5 per destination token / $10 per origin token)
-      expect(estimatedPayment.toNumber()).to.equal(1_000_000);
+      // * 10 gas price * ($5.5 per destination token / $9.0909 per origin token)
+      expect(estimatedPayment.toNumber()).to.equal(1_210_000);
     });
   });
 
@@ -160,8 +160,8 @@ describe('InterchainGasCalculator', () => {
       );
 
       // (100_000 dest handler gas + 100_000 process overhead gas)
-      // * 10 gas price * ($5 per destination token / $10 per origin token)
-      expect(estimatedPayment.toNumber()).to.equal(1_000_000);
+      // * 10 gas price * ($5.5 per destination token / $9.0909 per origin token)
+      expect(estimatedPayment.toNumber()).to.equal(1_210_001);
     });
   });
   */
@@ -176,7 +176,8 @@ describe('InterchainGasCalculator', () => {
         destinationWei,
       );
 
-      expect(originWei.toNumber()).to.equal(500);
+      // 1000 * (5.5 / 9.0909)
+      expect(originWei.toNumber()).to.equal(605);
     });
 
     it('considers when the origin token decimals > the destination token decimals', async () => {
@@ -193,7 +194,8 @@ describe('InterchainGasCalculator', () => {
         destinationWei,
       );
 
-      expect(originWei.toNumber()).to.equal(50000);
+      // 1000 * (5.5 / 9.0909) * 100
+      expect(originWei.toNumber()).to.equal(60500);
     });
 
     it('considers when the origin token decimals < the destination token decimals', async () => {
@@ -212,7 +214,8 @@ describe('InterchainGasCalculator', () => {
         destinationWei,
       );
 
-      expect(originWei.toNumber()).to.equal(5);
+      // 1000 * (5.5 / 9.0909) / 100
+      expect(originWei.toNumber()).to.equal(6);
     });
   });
 

--- a/typescript/sdk/src/gas/calculator.test.ts
+++ b/typescript/sdk/src/gas/calculator.test.ts
@@ -161,7 +161,7 @@ describe('InterchainGasCalculator', () => {
 
       // (100_000 dest handler gas + 100_000 process overhead gas)
       // * 10 gas price * ($5.5 per destination token / $9.0909 per origin token)
-      expect(estimatedPayment.toNumber()).to.equal(1_210_001);
+      expect(estimatedPayment.toNumber()).to.equal(1_210_000);
     });
   });
   */

--- a/typescript/sdk/src/gas/calculator.ts
+++ b/typescript/sdk/src/gas/calculator.ts
@@ -163,7 +163,7 @@ export class InterchainGasCalculator<Chain extends ChainName> {
    * a message.
    * @param origin The name of the origin chain.
    * @param destination The name of the destination chain.
-   * @param destinationHandleGas The amount of gas the recipient `handle` function
+   * @param handleGas The amount of gas the recipient `handle` function
    * is estimated to use.
    * @returns An estimated amount of origin chain tokens to cover gas costs of the
    * message on the destination chain.

--- a/typescript/sdk/src/gas/calculator.ts
+++ b/typescript/sdk/src/gas/calculator.ts
@@ -226,7 +226,7 @@ export class InterchainGasCalculator<Chain extends ChainName> {
     const PRECISION = 1000;
 
     return convertDecimalValue(
-      value.mul(exchangeRate * PRECISION).div(PRECISION),
+      value.mul(Math.round(exchangeRate * PRECISION)).div(PRECISION),
       this.tokenDecimals(fromChain),
       this.tokenDecimals(toChain),
     );


### PR DESCRIPTION
* Deploys key funder on testnet2 and mainnet to fund Kathy keys
* Upon trying to deploy #889, I came across some issues that my local testing unfortunately didn't catch:
   1. There's a bug in the current InterchainGasCalculator that causes an error to be thrown when the exchange rate isn't an integer! If you try to create an `ethers.BigNumber` from a non-integer `number`, it'll throw with something like: `underflow [ See: https://links.ethers.org/v5-errors-NUMERIC_FAULT-underflow ] (fault="underflow", operation="BigNumber.from", value=605.000605000605, code=NUMERIC_FAULT, version=bignumber/5.6.2)`. The fix here was to just round to the nearest integer, which is acceptable because we're using the PRECISION multiplier. I ran into this for the first time when deploying Kathy to mainnet. We didn't catch this earlier because (a) the unit tests previously used prices that were integers (changed this) and (b) the exchange rate of testnet tokens is hardcoded to 1:1. We'll need to ship a new SDK NPM version with this fix.
   2. The AWS User used by a deployed Kathy has less permissions than I have locally. I was able to locally list all keys and find keys based of aliases this way, but the user in the infra was not able to. I changed the infra to instead use the `DescribeKey` command, and modified the key policy so that the AWS User has the ability to describe the key in question.
* Some minor drive-bys

Note that the image used on testnet2's helloworld is from a commit in this PR/branch, which was necessary to test that everything in this PR is working correctly. Upon merging this I'll change that to a commit from main, and I'll make the deploy on mainnet.