### PR TITLE
Fix IGC price fetching for optimism/arb, for now don't pay correct interchain gas in Kathy

### DIFF
--- a/typescript/infra/scripts/helloworld/kathy.ts
+++ b/typescript/infra/scripts/helloworld/kathy.ts
@@ -195,14 +195,29 @@ async function sendMessage(
   const startTime = Date.now();
   const msg = 'Hello!';
   const expectedHandleGas = BigNumber.from(100_000);
-  const value = await gasCalc.estimatePaymentForHandleGas(
+  let value = await gasCalc.estimatePaymentForHandleGas(
     origin,
     destination,
     expectedHandleGas,
   );
   const metricLabels = { origin, remote: destination };
 
-  log('Sending message', { origin, destination });
+  log('Sending message', {
+    origin,
+    destination,
+    interchainGasPayment: value.toString(),
+  });
+
+  // For now, pay just 1 wei, as Kathy typically doesn't have enough
+  // funds to send from a cheap chain to expensive chains like Ethereum.
+  //
+  // TODO remove this once the Kathy key is funded with a higher
+  // balance and interchain gas payments are cycled back into
+  // the funder frequently.
+  value = BigNumber.from(1);
+  // Log it as an obvious reminder
+  log('Intentionally setting interchain gas payment to 1');
+
   const receipt = await utils.timeout(
     app.sendHelloWorld(origin, destination, msg, value),
     MESSAGE_SEND_TIMEOUT,

--- a/typescript/sdk/src/consts/chainMetadata.ts
+++ b/typescript/sdk/src/consts/chainMetadata.ts
@@ -10,7 +10,7 @@ export type ChainMetadata = {
   paginate?: RpcPagination;
   // The CoinGecko API expects, in some cases, IDs that do not match
   // ChainNames.
-  coinGeckoId?: string;
+  gasCurrencyCoinGeckoId?: string;
 };
 
 /**
@@ -41,17 +41,19 @@ export const ethereum: ChainMetadata = {
 export const arbitrum: ChainMetadata = {
   id: 0x617262, // b'arb' interpreted as an int
   finalityBlocks: 0,
+  gasCurrencyCoinGeckoId: 'ethereum', // ETH is used for gas
 };
 
 export const optimism: ChainMetadata = {
   id: 0x6f70, // b'op' interpreted as an int
   finalityBlocks: 0,
+  gasCurrencyCoinGeckoId: 'ethereum', // ETH is used for gas
 };
 
 export const bsc: ChainMetadata = {
   id: 0x627363, // b'bsc' interpreted as an int
   finalityBlocks: 15,
-  coinGeckoId: 'binancecoin',
+  gasCurrencyCoinGeckoId: 'binancecoin',
 };
 
 export const avalanche: ChainMetadata = {
@@ -62,7 +64,7 @@ export const avalanche: ChainMetadata = {
     blocks: 100000,
     from: 6765067,
   },
-  coinGeckoId: 'avalanche-2',
+  gasCurrencyCoinGeckoId: 'avalanche-2',
 };
 
 export const polygon: ChainMetadata = {
@@ -73,7 +75,7 @@ export const polygon: ChainMetadata = {
     blocks: 10000,
     from: 19657100,
   },
-  coinGeckoId: 'matic-network',
+  gasCurrencyCoinGeckoId: 'matic-network',
 };
 
 /**

--- a/typescript/sdk/src/gas/token-prices.test.ts
+++ b/typescript/sdk/src/gas/token-prices.test.ts
@@ -10,7 +10,7 @@ describe('TokenPriceGetter', () => {
   const chainA = Chains.ethereum,
     chainB = Chains.polygon,
     priceA = 10,
-    priceB = 5;
+    priceB = 5.5;
   beforeEach(async () => {
     const mockCoinGecko = new MockCoinGecko();
     // Origin token

--- a/typescript/sdk/src/gas/token-prices.ts
+++ b/typescript/sdk/src/gas/token-prices.ts
@@ -56,7 +56,7 @@ export class CoinGeckoTokenPriceGetter implements TokenPriceGetter {
     // The CoinGecko API expects, in some cases, IDs that do not match
     // ChainNames.
     const ids = chains.map(
-      (chain) => chainMetadata[chain].coinGeckoId || chain,
+      (chain) => chainMetadata[chain].gasCurrencyCoinGeckoId || chain,
     );
     const response = await this.coinGecko.simple.price({
       ids,

--- a/typescript/sdk/src/test/testUtils.ts
+++ b/typescript/sdk/src/test/testUtils.ts
@@ -58,7 +58,7 @@ export class MockCoinGecko implements CoinGeckoInterface {
     this.tokenPrices = {};
     this.idToChain = {};
     for (const chain of AllChains) {
-      const id = chainMetadata[chain].coinGeckoId || chain;
+      const id = chainMetadata[chain].gasCurrencyCoinGeckoId || chain;
       this.idToChain[id] = chain;
     }
   }

--- a/typescript/sdk/src/test/testUtils.ts
+++ b/typescript/sdk/src/test/testUtils.ts
@@ -1,7 +1,6 @@
 import { ethers } from 'ethers';
 
 import { chainMetadata } from '../consts/chainMetadata';
-import { AllChains } from '../consts/chains';
 import {
   CoinGeckoInterface,
   CoinGeckoResponse,
@@ -51,23 +50,18 @@ export class MockProvider extends ethers.providers.BaseProvider {
 
 // A mock CoinGecko intended to be used by tests
 export class MockCoinGecko implements CoinGeckoInterface {
-  private tokenPrices: Partial<ChainMap<ChainName, number>>;
-  private idToChain: Record<string, ChainName>;
+  // Prices keyed by coingecko id
+  private tokenPrices: Record<string, number>;
 
   constructor() {
     this.tokenPrices = {};
-    this.idToChain = {};
-    for (const chain of AllChains) {
-      const id = chainMetadata[chain].gasCurrencyCoinGeckoId || chain;
-      this.idToChain[id] = chain;
-    }
   }
 
   price(params: CoinGeckoSimplePriceParams): CoinGeckoResponse {
     const data: any = {};
     for (const id of params.ids) {
       data[id] = {
-        usd: this.tokenPrices[this.idToChain[id]],
+        usd: this.tokenPrices[id],
       };
     }
     return Promise.resolve({
@@ -83,7 +77,8 @@ export class MockCoinGecko implements CoinGeckoInterface {
   }
 
   setTokenPrice(chain: ChainName, price: number) {
-    this.tokenPrices[chain] = price;
+    const id = chainMetadata[chain].gasCurrencyCoinGeckoId || chain;
+    this.tokenPrices[id] = price;
   }
 }
 


### PR DESCRIPTION
* Gas is paid for on Optimism and Arbitrum in ETH, which the current code did not accommodate
* Noticing that the Kathy balance isn't high enough on some cheap chains (like Opt/Arb) to cover the whole cost of an expensive chain like Ethereum. For now, I'm having kathy still do the IGC calculation, but only pay 1 wei as gas payment. I've created #901 to undo this change once we have a high enough balance and are claiming IGP payments regularly