### PR TITLE
Transfer owner as a no-op

### DIFF
--- a/typescript/infra/config/environments/testnet2/core.ts
+++ b/typescript/infra/config/environments/testnet2/core.ts
@@ -4,6 +4,7 @@ import { TestnetChains } from './chains';
 
 export const core: ChainMap<TestnetChains, CoreConfig> = {
   alfajores: {
+    owner: '0xfaD1C94469700833717Fa8a3017278BC1cA8031C',
     validatorManager: {
       validators: [
         '0x7716860b2be4079137dc21533ac6d26a99d76e83',
@@ -14,6 +15,7 @@ export const core: ChainMap<TestnetChains, CoreConfig> = {
     },
   },
   kovan: {
+    owner: '0xfaD1C94469700833717Fa8a3017278BC1cA8031C',
     validatorManager: {
       validators: [
         '0x1ee94e776cbe4bf74d2f80dae551758efbc21887',
@@ -24,6 +26,7 @@ export const core: ChainMap<TestnetChains, CoreConfig> = {
     },
   },
   fuji: {
+    owner: '0xfaD1C94469700833717Fa8a3017278BC1cA8031C',
     validatorManager: {
       validators: [
         '0xc0ab1f3e3317521a92462927849b8844cf408b09',
@@ -34,6 +37,7 @@ export const core: ChainMap<TestnetChains, CoreConfig> = {
     },
   },
   mumbai: {
+    owner: '0xfaD1C94469700833717Fa8a3017278BC1cA8031C',
     validatorManager: {
       validators: [
         '0x0f1a231cb2ecc5f26696c433d76fe59521a227e0',
@@ -44,6 +48,7 @@ export const core: ChainMap<TestnetChains, CoreConfig> = {
     },
   },
   bsctestnet: {
+    owner: '0xfaD1C94469700833717Fa8a3017278BC1cA8031C',
     validatorManager: {
       validators: [
         '0xa7959b2f03f6fc77c9592547bd0ca12fe2c7bf8f',
@@ -54,6 +59,7 @@ export const core: ChainMap<TestnetChains, CoreConfig> = {
     },
   },
   arbitrumrinkeby: {
+    owner: '0xfaD1C94469700833717Fa8a3017278BC1cA8031C',
     validatorManager: {
       validators: [
         '0xf5a871bcb9d6dfa2d3519caf396e7ab3c5a7a2ee',
@@ -64,6 +70,7 @@ export const core: ChainMap<TestnetChains, CoreConfig> = {
     },
   },
   optimismkovan: {
+    owner: '0xfaD1C94469700833717Fa8a3017278BC1cA8031C',
     validatorManager: {
       validators: [
         '0xef0d7bbb9c71fef7dc148722060afd78d0ff09d8',

--- a/typescript/infra/src/core/govern.ts
+++ b/typescript/infra/src/core/govern.ts
@@ -82,6 +82,9 @@ export class AbacusCoreGovernor<Chain extends ChainName> {
     console.log(
       `${violation.chain}: transferring ownership of ${violation.data.contract.address} from ${violation.actual} to ${violation.expected}`,
     );
+    if (violation.actual != violation.expected) {
+      throw new Error('error');
+    }
     const response = await violation.data.contract.transferOwnership(
       violation.expected,
       chainConnection.overrides,

--- a/typescript/sdk/src/deploy/AbacusAppChecker.ts
+++ b/typescript/sdk/src/deploy/AbacusAppChecker.ts
@@ -68,7 +68,7 @@ export abstract class AbacusAppChecker<
     await Promise.all(
       ownables.map(async (contract) => {
         const actual = await contract.owner();
-        if (actual.toLowerCase() != owner.toLowerCase()) {
+        if (actual.toLowerCase() === owner.toLowerCase()) {
           const violation: OwnerViolation = {
             chain,
             type: ViolationType.Owner,


### PR DESCRIPTION
This change just creates a bunch of "virtual" violations so that transfer owner can be called as a no-op. This is done to create some txs on proxies which will help etherscan detect them as a proxy.