### PR TITLE
Try to assert the message was processed via contract state

### DIFF
--- a/typescript/infra/scripts/helloworld/kathy.ts
+++ b/typescript/infra/scripts/helloworld/kathy.ts
@@ -261,7 +261,10 @@ async function sendMessage(
     // If we weren't able to get the receipt for message processing, try to read the state to ensure it wasn't a transient provider issue
     const channelStatsNow = await app.channelStats(origin, destination);
     if (channelStatsNow.received <= channelStatsBefore.received) {
-      log("Did not receive event for message delivery even though it was delivered", {origin, destination})
+      log(
+        'Did not receive event for message delivery even though it was delivered',
+        { origin, destination },
+      );
       throw error;
     }
   }

--- a/typescript/infra/scripts/helloworld/kathy.ts
+++ b/typescript/infra/scripts/helloworld/kathy.ts
@@ -259,7 +259,7 @@ async function sendMessage(
     );
   } catch (error) {
     // If we weren't able to get the receipt for message processing, try to read the state to ensure it wasn't a transient provider issue
-    const statsAfter = await app.channelStats(origin, destination);
+    const channelStatsNow = await app.channelStats(origin, destination);
     if (statsAfter.received === statsBefore.received) {
       throw error;
     }

--- a/typescript/infra/scripts/helloworld/kathy.ts
+++ b/typescript/infra/scripts/helloworld/kathy.ts
@@ -237,7 +237,7 @@ async function sendMessage(
   // Log it as an obvious reminder
   log('Intentionally setting interchain gas payment to 1');
 
-  const statsBefore = await app.channelStats(origin, destination);
+  const channelStatsBefore = await app.channelStats(origin, destination);
   const receipt = await utils.timeout(
     app.sendHelloWorld(origin, destination, msg, value),
     MESSAGE_SEND_TIMEOUT,

--- a/typescript/infra/scripts/helloworld/kathy.ts
+++ b/typescript/infra/scripts/helloworld/kathy.ts
@@ -260,7 +260,8 @@ async function sendMessage(
   } catch (error) {
     // If we weren't able to get the receipt for message processing, try to read the state to ensure it wasn't a transient provider issue
     const channelStatsNow = await app.channelStats(origin, destination);
-    if (statsAfter.received === statsBefore.received) {
+    if (channelStatsNow.received <= channelStatsBefore.received) {
+      log("Did not receive event for message delivery even though it was delivered", {origin, destination})
       throw error;
     }
   }


### PR DESCRIPTION
Fixes #922 

This PR tries to assert message processing via the stats stored on the HelloWorld contract