### PR TITLE
Add leaf index as a key on the log line

### DIFF
--- a/rust/agents/relayer/src/msg/serial_submitter.rs
+++ b/rust/agents/relayer/src/msg/serial_submitter.rs
@@ -228,7 +228,7 @@ impl SerialSubmitter {
                 info!(msg=?msg, "Message processed");
             }
             Err(e) => {
-                info!(msg=?msg, leaf_index=msg.leaf_index, error=?e, "Message processing failed: {}", e);
+                info!(msg=?msg, leaf_index=msg.leaf_index, error=?e, "Message processing failed");
                 msg.num_retries += 1;
                 self.run_queue.push(msg);
             }

--- a/rust/agents/relayer/src/msg/serial_submitter.rs
+++ b/rust/agents/relayer/src/msg/serial_submitter.rs
@@ -228,7 +228,7 @@ impl SerialSubmitter {
                 info!(msg=?msg, "Message processed");
             }
             Err(e) => {
-                info!(msg=?msg, "Message processing failed: {}", e);
+                info!(msg=?msg, leaf_index=msg.leaf_index, error=?e, "Message processing failed: {}", e);
                 msg.num_retries += 1;
                 self.run_queue.push(msg);
             }


### PR DESCRIPTION
This allows GCP to correctly filter for it in stackdriver logging