### PR TITLE
Push failing messages to the back of the run queue

### DIFF
--- a/rust/agents/relayer/src/msg/serial_submitter.rs
+++ b/rust/agents/relayer/src/msg/serial_submitter.rs
@@ -184,13 +184,11 @@ impl SerialSubmitter {
         // Promote any newly-ready messages from the wait queue to the run queue.
         // The order of wait_messages is preserved and pushed at the front of the run_queue
         // to ensure that new messages are evaluated first.
-        let wait_messages: Vec<_> = self.wait_queue.drain(..).rev().collect();
-        for msg in wait_messages {
+        for msg in self.wait_queue.drain(..).rev() {
             // TODO(webbhorn): Check against interchain gas paymaster.  If now enough payment,
             // promote to run queue.
             self.run_queue.push_front(msg);
         }
-        self.wait_queue = Vec::new();
 
         self.metrics
             .wait_queue_length_gauge

--- a/rust/agents/relayer/src/msg/serial_submitter.rs
+++ b/rust/agents/relayer/src/msg/serial_submitter.rs
@@ -1,4 +1,4 @@
-use std::collections::BinaryHeap;
+use std::collections::VecDeque;
 
 use abacus_base::CoreMetrics;
 use abacus_base::InboxContracts;
@@ -91,18 +91,18 @@ use super::SubmitMessageArgs;
 ///       reasons listed above (e.g. index not covered by checkpoint, insufficient gas, etc).
 ///
 /// Note that there is no retry queue. This is because if submission fails for a retriable
-/// reason, the message instead goes directly back on to the runnable queue (though it will be
-/// prioritized lower than it was prior to the failed attempt due to the increased
-/// num_retries).
+/// reason, the message instead goes directly back on to the runnable queue.
+/// If submission fails, the message is sent to the back of the queue. This is to ensure
+/// all messages are retried frequently, and not just those that happen to have a lower
+/// retry count.
 ///
 /// To summarize: each scheduler `tick()`, new messages from the processor are inserted onto
 /// the wait queue.  We then scan the wait_queue, looking for messages which can be promoted to
 /// the runnable_queue, e.g. by comparing with a recent checkpoint or latest gas payments on
 /// source chain. If eligible for delivery, the message is promoted to the runnable queue and
-/// prioritized accordingly. Note that for messages that have never been attempted before, they
-/// will sort very highly due to num_retries==0 and probably be tried soon.
+/// prioritized accordingly. These messages that have never been tried before are pushed to
+/// the front of the runnable queue.
 
-// TODO(webbhorn): Metrics data.
 // TODO(webbhorn): Do we also want to await finality_blocks on source chain before attempting
 // submission? Does this already happen?
 
@@ -117,7 +117,7 @@ pub(crate) struct SerialSubmitter {
     /// Messages that are in theory deliverable, but which are waiting in a queue for their turn
     /// to be dispatched. The SerialSubmitter can only dispatch one message at a time, so this
     /// queue could grow.
-    run_queue: BinaryHeap<SubmitMessageArgs>,
+    run_queue: VecDeque<SubmitMessageArgs>,
     /// Inbox / InboxValidatorManager on the destination chain.
     inbox_contracts: InboxContracts,
     /// Interface to agent rocks DB for e.g. writing delivery status upon completion.
@@ -136,7 +136,7 @@ impl SerialSubmitter {
         Self {
             rx,
             wait_queue: Vec::new(),
-            run_queue: BinaryHeap::new(),
+            run_queue: VecDeque::new(),
             inbox_contracts,
             db,
             metrics,
@@ -182,11 +182,13 @@ impl SerialSubmitter {
         // queue for further processing.
 
         // Promote any newly-ready messages from the wait queue to the run queue.
-        let wait_messages: Vec<_> = self.wait_queue.drain(..).collect();
+        // The order of wait_messages is preserved and pushed at the front of the run_queue
+        // to ensure that new messages are evaluated first.
+        let wait_messages: Vec<_> = self.wait_queue.drain(..).rev().collect();
         for msg in wait_messages {
-            // TODO(webbhorn): Check against interchain gas paymaster.  If now enough payment,
+            // TODO(webbhorn): Check against interchain gas paymaster.  If not enough payment,
             // promote to run queue.
-            self.run_queue.push(msg);
+            self.run_queue.push_front(msg);
         }
         self.wait_queue = Vec::new();
 
@@ -198,7 +200,7 @@ impl SerialSubmitter {
             .set(self.run_queue.len() as i64);
 
         // Pick the next message to try processing.
-        let mut msg = match self.run_queue.pop() {
+        let mut msg = match self.run_queue.pop_front() {
             Some(m) => m,
             None => return Ok(()),
         };
@@ -230,7 +232,7 @@ impl SerialSubmitter {
             Err(e) => {
                 info!(msg=?msg, "Message processing failed: {}", e);
                 msg.num_retries += 1;
-                self.run_queue.push(msg);
+                self.run_queue.push_back(msg);
             }
         }
 

--- a/rust/agents/relayer/src/msg/serial_submitter.rs
+++ b/rust/agents/relayer/src/msg/serial_submitter.rs
@@ -186,7 +186,7 @@ impl SerialSubmitter {
         // to ensure that new messages are evaluated first.
         let wait_messages: Vec<_> = self.wait_queue.drain(..).rev().collect();
         for msg in wait_messages {
-            // TODO(webbhorn): Check against interchain gas paymaster.  If not enough payment,
+            // TODO(webbhorn): Check against interchain gas paymaster.  If now enough payment,
             // promote to run queue.
             self.run_queue.push_front(msg);
         }

--- a/rust/agents/relayer/src/msg/serial_submitter.rs
+++ b/rust/agents/relayer/src/msg/serial_submitter.rs
@@ -225,6 +225,9 @@ impl SerialSubmitter {
 
         // Go ahead and attempt processing of message to destination chain.
         debug!(msg=?msg, "Ready to process message");
+        // TODO: consider differentiating types of processing errors, and pushing to the front of the
+        // run queue for intermittent types of errors that can occur even if a message's processing isn't
+        // reverting, e.g. timeouts or txs being dropped from the mempool.
         match self.process_message(&msg).await {
             Ok(()) => {
                 info!(msg=?msg, "Message processed");


### PR DESCRIPTION
* Rather than sorting the run queue by the # of retries, this will instead push new messages from the wait queue into the front of the run queue, but will push any messages that are reverting to the back of the run queue, which is now ordered in a FIFO manner. See #919 for context.
* Note just pushing to the back of the queue for all kinds of processing errors can have some consequences because it's possible for message processing to fail for reasons other than the message reverting. For example, sometimes we can get into a situation where a transaction doesn't get mined within 5 mins and times out, and ideally we should just retry the same message. Because we expect the run queue to stay small and for these timeouts to occur very infrequently, this is probably not an issue, but we should keep this in mind for the future and consider pushing to the front of the run queue if the message isn't reverting and should be retried.