### PR TITLE
Don't use retrying provider when using Celo

### DIFF
--- a/typescript/infra/src/config/chain.ts
+++ b/typescript/infra/src/config/chain.ts
@@ -10,9 +10,13 @@ import { DeployEnvironment } from './environment';
 const CELO_CHAIN_NAMES = new Set(['alfajores', 'baklava', 'celo']);
 
 const providerBuilder = (url: string, chainName: ChainName, retry = true) => {
-  const baseProvider = CELO_CHAIN_NAMES.has(chainName)
-    ? new StaticCeloJsonRpcProvider(url)
-    : new ethers.providers.JsonRpcProvider(url);
+  // TODO: get StaticCeloJsonRpcProvider to be compatible with the RetryJsonRpcProvider.
+  // For now, the two are incompatible, so even if retrying is requested for a Celo chain,
+  // we don't use a RetryJsonRpcProvider.
+  if (CELO_CHAIN_NAMES.has(chainName)) {
+    return new StaticCeloJsonRpcProvider(url);
+  }
+  const baseProvider = new ethers.providers.JsonRpcProvider(url);
   return retry
     ? new RetryJsonRpcProvider(baseProvider, {
         maxRequests: 6,


### PR DESCRIPTION
The `RetryJsonRpcProvider` is incompatible with `StaticCeloJsonRpcProvider` for Celo chains. For now, just not retrying for Celo chains.

This was the error for anyone curious. Tested to ensure this was the issue.

```
{"error":"Error: invalid BigNumber value (argument=\"value\", value=undefined, code=INVALID_ARGUMENT, version=bignumber/5.6.2)\n    at Logger.makeError (/abacus-monorepo/node_modules/@ethersproject/logger/src.ts/index.ts:261:28)\n    at Logger.throwError (/abacus-monorepo/node_modules/@ethersproject/logger/src.ts/index.ts:273:20)\n    at Logger.throwArgumentError (/abacus-monorepo/node_modules/@ethersproject/logger/src.ts/index.ts:277:21)\n    at Function.BigNumber.from (/abacus-monorepo/node_modules/@ethersproject/bignumber/src.ts/bignumber.ts:289:23)\n    at Formatter.bigNumber (/abacus-monorepo/node_modules/@ethersproject/providers/src.ts/formatter.ts:199:26)\n    at Function.Formatter.check (/abacus-monorepo/node_modules/@ethersproject/providers/src.ts/formatter.ts:448:42)\n    at Formatter._block (/abacus-monorepo/node_modules/@ethersproject/providers/src.ts/formatter.ts:299:34)\n    at Formatter.block (/abacus-monorepo/node_modules/@ethersproject/providers/src.ts/formatter.ts:305:21)\n    at RetryJsonRpcProvider.<anonymous> (/abacus-monorepo/node_modules/@ethersproject/providers/src.ts/base-provider.ts:1828:35)\n    at step (/abacus-monorepo/node_modules/@ethersproject/providers/lib/base-provider.js:48:23) {\n  reason: 'invalid BigNumber value',\n  code: 'INVALID_ARGUMENT',\n  argument: 'value',\n  value: undefined,\n  checkKey: 'gasLimit',\n  checkValue: undefined\n}","currentPairingIndex":23,"origin":"alfajores","destination":"optimismkovan","level":"error","message":"Error sending message, continuing..."}
```