### PR TITLE
Change indexing log messages

### DIFF
--- a/rust/abacus-base/src/contract_sync/interchain_gas.rs
+++ b/rust/abacus-base/src/contract_sync/interchain_gas.rs
@@ -69,7 +69,7 @@ where
                     from = full_chunk_from,
                     to = to,
                     gas_payments_count = gas_payments.len(),
-                    "[GasPayments]: indexed block heights {from}...{to}"
+                    "[GasPayments]: indexed block range"
                 );
 
                 for gas_payment in gas_payments.iter() {

--- a/rust/abacus-base/src/contract_sync/outbox.rs
+++ b/rust/abacus-base/src/contract_sync/outbox.rs
@@ -117,7 +117,7 @@ where
                     from = full_chunk_from,
                     to = to,
                     message_count = sorted_messages.len(),
-                    "[Messages]: indexed block heights {full_chunk_from}...{to}"
+                    "[Messages]: indexed block range"
                 );
 
                 // Get the latest known leaf index. All messages whose indices are <= this index


### PR DESCRIPTION
Noticed the `from` in the GasPayments log message wasn't the `full_chunk_from`. Instead, just removing any variables from the message so it's easier to search for logs based off the message