### PR TITLE
Safely access process.env

### DIFF
--- a/typescript/sdk/src/test/envSubsetDeployer/utils.ts
+++ b/typescript/sdk/src/test/envSubsetDeployer/utils.ts
@@ -1,6 +1,7 @@
 import { Wallet } from 'ethers';
 
 import { StaticCeloJsonRpcProvider } from '@abacus-network/celo-ethers-provider';
+import { utils } from '@abacus-network/utils';
 
 export const ALFAJORES_FORNO = 'https://alfajores-forno.celo-testnet.org';
 export const CELO_DERIVATION_PATH = "m/44'/52752'/0'/0/0";
@@ -8,7 +9,7 @@ export const CELO_DERIVATION_PATH = "m/44'/52752'/0'/0/0";
 export function getAlfajoresSigner() {
   console.info('Getting signer');
   const provider = getAlfajoresProvider();
-  const mnemonic = process.env.MNEMONIC;
+  const mnemonic = utils.safelyAccessEnvVar('MNEMONIC');
   if (!mnemonic) throw new Error('No MNEMONIC provided in env');
   const wallet = Wallet.fromMnemonic(mnemonic, CELO_DERIVATION_PATH).connect(
     provider,

--- a/typescript/utils/src/logging.ts
+++ b/typescript/utils/src/logging.ts
@@ -1,8 +1,10 @@
+import { safelyAccessEnvVar } from './utils';
+
 /* eslint-disable no-console */
 type LOG_LEVEL = 'none' | 'error' | 'warn' | 'info' | 'debug' | 'trace';
 
 const ENV_LOG_LEVEL = (
-  process.env['LOG_LEVEL'] ?? 'debug'
+  safelyAccessEnvVar('LOG_LEVEL') ?? 'debug'
 ).toLowerCase() as LOG_LEVEL;
 const LOG_TRACE = ENV_LOG_LEVEL == 'trace';
 const LOG_DEBUG = LOG_TRACE || ENV_LOG_LEVEL == 'debug';

--- a/typescript/utils/src/utils.ts
+++ b/typescript/utils/src/utils.ts
@@ -186,3 +186,13 @@ export function timeout<T>(
     promise.then(resolve).catch(reject);
   });
 }
+
+// Should be used instead of referencing process directly in case we don't
+// run in node.js
+export function safelyAccessEnvVar(name: string) {
+  try {
+    return process.env[name];
+  } catch (error) {
+    return undefined;
+  }
+}


### PR DESCRIPTION
When running the SDK in non-node.js environment we would get a reference error

Fixes #959