### PR TITLE
Prevent replayable messages on new `Inbox` versions (as enrolled on `AbacusConnectionManager`)

### DIFF
--- a/solidity/core/contracts/AbacusConnectionManager.sol
+++ b/solidity/core/contracts/AbacusConnectionManager.sol
@@ -81,7 +81,10 @@ contract AbacusConnectionManager is IAbacusConnectionManager, Ownable {
 
         // prevent enrolling an inbox that matches any previously enrolled domain hash
         bytes32 domainHash = getDomainHash(_inbox);
-        require(!domainHashes.contains(domainHash), "domain hash in use");
+        require(
+            !domainHashes.contains(domainHash),
+            "domain hash previously enrolled"
+        );
         domainHashes.add(domainHash);
 
         // add inbox and domain to two-way mapping

--- a/solidity/core/contracts/AbacusConnectionManager.sol
+++ b/solidity/core/contracts/AbacusConnectionManager.sol
@@ -78,7 +78,7 @@ contract AbacusConnectionManager is IAbacusConnectionManager, Ownable {
      * @param _inbox the address of the Inbox
      */
     function enrollInbox(uint32 _domain, address _inbox) external onlyOwner {
-        _domain = _domain; // suppress unused variable warning
+        _domain; // suppress unused variable warning
         enrollInboxAddress(_inbox);
     }
 

--- a/solidity/core/contracts/Inbox.sol
+++ b/solidity/core/contracts/Inbox.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.0;
 
 // ============ Internal Imports ============
-import {Version0} from "./Version0.sol";
+import {Versioned} from "./upgrade/Versioned.sol";
 import {Mailbox} from "./Mailbox.sol";
 import {MerkleLib} from "./libs/Merkle.sol";
 import {Message} from "./libs/Message.sol";
@@ -19,7 +19,7 @@ import {ReentrancyGuardUpgradeable} from "@openzeppelin/contracts-upgradeable/se
  * @notice Track root updates on Outbox, prove and dispatch messages to end
  * recipients.
  */
-contract Inbox is IInbox, ReentrancyGuardUpgradeable, Version0, Mailbox {
+contract Inbox is IInbox, ReentrancyGuardUpgradeable, Versioned, Mailbox {
     // ============ Libraries ============
 
     using MerkleLib for MerkleLib.Tree;

--- a/solidity/core/contracts/Outbox.sol
+++ b/solidity/core/contracts/Outbox.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.0;
 
 // ============ Internal Imports ============
-import {Version0} from "./Version0.sol";
+import {Versioned} from "./upgrade/Versioned.sol";
 import {Mailbox} from "./Mailbox.sol";
 import {MerkleLib} from "./libs/Merkle.sol";
 import {Message} from "./libs/Message.sol";
@@ -20,7 +20,7 @@ import {IOutbox} from "../interfaces/IOutbox.sol";
  * Accepts submissions of fraudulent signatures
  * by the Validator and slashes the Validator in this case.
  */
-contract Outbox is IOutbox, Version0, MerkleTreeManager, Mailbox {
+contract Outbox is IOutbox, Versioned, MerkleTreeManager, Mailbox {
     // ============ Libraries ============
 
     using MerkleLib for MerkleLib.Tree;

--- a/solidity/core/contracts/upgrade/Versioned.sol
+++ b/solidity/core/contracts/upgrade/Versioned.sol
@@ -2,9 +2,9 @@
 pragma solidity >=0.6.11;
 
 /**
- * @title Version0
+ * @title Versioned
  * @notice Version getter for contracts
  **/
-contract Version0 {
+contract Versioned {
     uint8 public constant VERSION = 0;
 }

--- a/solidity/core/contracts/validator-manager/MultisigValidatorManager.sol
+++ b/solidity/core/contracts/validator-manager/MultisigValidatorManager.sol
@@ -256,7 +256,8 @@ abstract contract MultisigValidatorManager is
     }
 
     /**
-     * @notice Hash of `_domain` concatenated with "ABACUS".
+     * @notice Hash of `_domain` concatenated with "ABACUS" and deployment version.
+     * @dev Domain hash is salted with deployment version to prevent validator signature replay.
      * @param _domain The domain to hash.
      */
     function _domainHash(uint32 _domain) internal pure returns (bytes32) {

--- a/solidity/core/contracts/validator-manager/MultisigValidatorManager.sol
+++ b/solidity/core/contracts/validator-manager/MultisigValidatorManager.sol
@@ -9,12 +9,19 @@ import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 
+// ============ Internal Imports ============
+import {IMultisigValidatorManager} from "../../interfaces/IMultisigValidatorManager.sol";
+
 /**
  * @title MultisigValidatorManager
  * @notice Manages an ownable set of validators that ECDSA sign checkpoints to
  * reach a quorum.
  */
-abstract contract MultisigValidatorManager is Ownable, Versioned {
+abstract contract MultisigValidatorManager is
+    IMultisigValidatorManager,
+    Ownable,
+    Versioned
+{
     // ============ Libraries ============
 
     using EnumerableSet for EnumerableSet.AddressSet;

--- a/solidity/core/contracts/validator-manager/MultisigValidatorManager.sol
+++ b/solidity/core/contracts/validator-manager/MultisigValidatorManager.sol
@@ -253,6 +253,11 @@ abstract contract MultisigValidatorManager is Ownable, Versioned {
      * @param _domain The domain to hash.
      */
     function _domainHash(uint32 _domain) internal pure returns (bytes32) {
-        return keccak256(abi.encodePacked(_domain, "ABACUS", VERSION));
+        if (VERSION > 0) {
+            return keccak256(abi.encodePacked(_domain, "ABACUS", VERSION));
+        } else {
+            // for backwards compatibility with initial deployment (VERSION == 0)
+            return keccak256(abi.encodePacked(_domain, "ABACUS"));
+        }
     }
 }

--- a/solidity/core/contracts/validator-manager/MultisigValidatorManager.sol
+++ b/solidity/core/contracts/validator-manager/MultisigValidatorManager.sol
@@ -70,11 +70,12 @@ abstract contract MultisigValidatorManager is Ownable {
     constructor(
         uint32 _domain,
         address[] memory _validators,
-        uint256 _threshold
+        uint256 _threshold,
+        uint8 _version
     ) Ownable() {
         // Set immutables.
         domain = _domain;
-        domainHash = _domainHash(_domain);
+        domainHash = _domainHash(_domain, _version);
 
         // Enroll validators. Reverts if there are any duplicates.
         uint256 _numValidators = _validators.length;
@@ -250,7 +251,11 @@ abstract contract MultisigValidatorManager is Ownable {
      * @notice Hash of `_domain` concatenated with "ABACUS".
      * @param _domain The domain to hash.
      */
-    function _domainHash(uint32 _domain) internal pure returns (bytes32) {
-        return keccak256(abi.encodePacked(_domain, "ABACUS"));
+    function _domainHash(uint32 _domain, uint8 _version)
+        internal
+        pure
+        returns (bytes32)
+    {
+        return keccak256(abi.encodePacked(_domain, "ABACUS", _version));
     }
 }

--- a/solidity/core/contracts/validator-manager/MultisigValidatorManager.sol
+++ b/solidity/core/contracts/validator-manager/MultisigValidatorManager.sol
@@ -2,6 +2,8 @@
 pragma solidity >=0.8.0;
 pragma abicoder v2;
 
+import {Versioned} from "../upgrade/Versioned.sol";
+
 // ============ External Imports ============
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
@@ -12,7 +14,7 @@ import {EnumerableSet} from "@openzeppelin/contracts/utils/structs/EnumerableSet
  * @notice Manages an ownable set of validators that ECDSA sign checkpoints to
  * reach a quorum.
  */
-abstract contract MultisigValidatorManager is Ownable {
+abstract contract MultisigValidatorManager is Ownable, Versioned {
     // ============ Libraries ============
 
     using EnumerableSet for EnumerableSet.AddressSet;
@@ -70,12 +72,11 @@ abstract contract MultisigValidatorManager is Ownable {
     constructor(
         uint32 _domain,
         address[] memory _validators,
-        uint256 _threshold,
-        uint8 _version
+        uint256 _threshold
     ) Ownable() {
         // Set immutables.
         domain = _domain;
-        domainHash = _domainHash(_domain, _version);
+        domainHash = _domainHash(_domain);
 
         // Enroll validators. Reverts if there are any duplicates.
         uint256 _numValidators = _validators.length;
@@ -251,11 +252,7 @@ abstract contract MultisigValidatorManager is Ownable {
      * @notice Hash of `_domain` concatenated with "ABACUS".
      * @param _domain The domain to hash.
      */
-    function _domainHash(uint32 _domain, uint8 _version)
-        internal
-        pure
-        returns (bytes32)
-    {
-        return keccak256(abi.encodePacked(_domain, "ABACUS", _version));
+    function _domainHash(uint32 _domain) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked(_domain, "ABACUS", VERSION));
     }
 }

--- a/solidity/core/interfaces/IMailbox.sol
+++ b/solidity/core/interfaces/IMailbox.sol
@@ -3,4 +3,6 @@ pragma solidity >=0.6.11;
 
 interface IMailbox {
     function localDomain() external view returns (uint32);
+
+    function validatorManager() external view returns (address);
 }

--- a/solidity/core/interfaces/IMultisigValidatorManager.sol
+++ b/solidity/core/interfaces/IMultisigValidatorManager.sol
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+pragma solidity >=0.6.0;
+
 interface IMultisigValidatorManager {
     function domain() external view returns (uint32);
 

--- a/solidity/core/interfaces/IMultisigValidatorManager.sol
+++ b/solidity/core/interfaces/IMultisigValidatorManager.sol
@@ -1,0 +1,8 @@
+interface IMultisigValidatorManager {
+    function domain() external view returns (uint32);
+
+    // The domain hash of the validator set's outbox chain.
+    function domainHash() external view returns (bytes32);
+
+    function threshold() external view returns (uint256);
+}

--- a/solidity/core/test/abacusConnectionManager.test.ts
+++ b/solidity/core/test/abacusConnectionManager.test.ts
@@ -5,10 +5,12 @@ import { ethers } from 'hardhat';
 import {
   AbacusConnectionManager,
   AbacusConnectionManager__factory,
+  MultisigValidatorManager,
   Outbox,
   Outbox__factory,
   TestInbox,
   TestInbox__factory,
+  TestMultisigValidatorManager__factory,
 } from '../types';
 
 const ONLY_OWNER_REVERT_MSG = 'Ownable: caller is not the owner';
@@ -17,6 +19,7 @@ const remoteDomain = 2000;
 
 describe('AbacusConnectionManager', async () => {
   let connectionManager: AbacusConnectionManager,
+    validatorManager: MultisigValidatorManager,
     enrolledInbox: TestInbox,
     signer: SignerWithAddress,
     nonOwner: SignerWithAddress;
@@ -31,9 +34,16 @@ describe('AbacusConnectionManager', async () => {
 
     const inboxFactory = new TestInbox__factory(signer);
     enrolledInbox = await inboxFactory.deploy(localDomain);
-    // The ValidatorManager is unused in these tests *but* needs to be a
-    // contract.
-    await enrolledInbox.initialize(remoteDomain, outbox.address);
+
+    const validatorManagerFactory = new TestMultisigValidatorManager__factory(
+      signer,
+    );
+    validatorManager = await validatorManagerFactory.deploy(
+      remoteDomain,
+      [signer.address],
+      1,
+    );
+    await enrolledInbox.initialize(remoteDomain, validatorManager.address);
 
     const connectionManagerFactory = new AbacusConnectionManager__factory(
       signer,
@@ -80,10 +90,19 @@ describe('AbacusConnectionManager', async () => {
       .false;
   });
 
-  it('Owner can enroll a inbox', async () => {
+  it('Owner can enroll multiple inboxes with different domain hashes', async () => {
     const newRemoteDomain = 3000;
     const inboxFactory = new TestInbox__factory(signer);
     const newInbox = await inboxFactory.deploy(localDomain);
+    const validatorManagerFactory = new TestMultisigValidatorManager__factory(
+      signer,
+    );
+    const newValidatorManager = await validatorManagerFactory.deploy(
+      newRemoteDomain,
+      [signer.address],
+      1,
+    );
+    await newInbox.initialize(newRemoteDomain, newValidatorManager.address);
 
     // Assert new inbox not considered inbox before enrolled
     expect(await connectionManager.isInbox(newInbox.address)).to.be.false;
@@ -116,37 +135,14 @@ describe('AbacusConnectionManager', async () => {
     expect(await connectionManager.isInbox(enrolledInbox.address)).to.be.false;
   });
 
-  it('Owner can enroll multiple inboxes per domain', async () => {
+  it('Owner cannot enroll multiple inboxes with same domain hash', async () => {
     const newRemoteDomain = 3000;
     const inboxFactory = new TestInbox__factory(signer);
-    const newInbox1 = await inboxFactory.deploy(localDomain);
-    const newInbox2 = await inboxFactory.deploy(localDomain);
-
-    // Assert new inbox not considered inbox before enrolled
-    expect(await connectionManager.isInbox(newInbox1.address)).to.be.false;
-    expect(await connectionManager.isInbox(newInbox2.address)).to.be.false;
-
+    const newInbox = await inboxFactory.deploy(localDomain);
+    await newInbox.initialize(newRemoteDomain, validatorManager.address);
     await expect(
-      connectionManager.enrollInbox(newRemoteDomain, newInbox1.address),
-    ).to.emit(connectionManager, 'InboxEnrolled');
-    await expect(
-      connectionManager.enrollInbox(newRemoteDomain, newInbox2.address),
-    ).to.emit(connectionManager, 'InboxEnrolled');
-
-    expect(await connectionManager.inboxToDomain(newInbox1.address)).to.equal(
-      newRemoteDomain,
-    );
-    expect(await connectionManager.inboxToDomain(newInbox2.address)).to.equal(
-      newRemoteDomain,
-    );
-
-    expect(await connectionManager.isInbox(newInbox1.address)).to.be.true;
-    expect(await connectionManager.isInbox(newInbox2.address)).to.be.true;
-
-    expect(await connectionManager.getInboxes(newRemoteDomain)).to.eql([
-      newInbox1.address,
-      newInbox2.address,
-    ]);
+      connectionManager.enrollInbox(newRemoteDomain, newInbox.address),
+    ).to.be.revertedWith('domain hash has been used');
   });
 
   it('Owner cannot enroll an inbox twice', async () => {

--- a/solidity/core/test/abacusConnectionManager.test.ts
+++ b/solidity/core/test/abacusConnectionManager.test.ts
@@ -142,7 +142,7 @@ describe('AbacusConnectionManager', async () => {
     await newInbox.initialize(newRemoteDomain, validatorManager.address);
     await expect(
       connectionManager.enrollInbox(newRemoteDomain, newInbox.address),
-    ).to.be.revertedWith('domain hash has been used');
+    ).to.be.revertedWith('domain hash in use');
   });
 
   it('Owner cannot enroll an inbox twice', async () => {

--- a/solidity/core/test/abacusConnectionManager.test.ts
+++ b/solidity/core/test/abacusConnectionManager.test.ts
@@ -136,19 +136,18 @@ describe('AbacusConnectionManager', async () => {
   });
 
   it('Owner cannot enroll multiple inboxes with same domain hash', async () => {
-    const newRemoteDomain = 3000;
     const inboxFactory = new TestInbox__factory(signer);
     const newInbox = await inboxFactory.deploy(localDomain);
-    await newInbox.initialize(newRemoteDomain, validatorManager.address);
+    await newInbox.initialize(remoteDomain, validatorManager.address);
+    await connectionManager.unenrollInbox(enrolledInbox.address);
     await expect(
-      connectionManager.enrollInbox(newRemoteDomain, newInbox.address),
-    ).to.be.revertedWith('domain hash in use');
+      connectionManager.enrollInbox(remoteDomain, newInbox.address),
+    ).to.be.revertedWith('domain hash previously enrolled');
   });
 
   it('Owner cannot enroll an inbox twice', async () => {
-    const newRemoteDomain = 3000;
     await expect(
-      connectionManager.enrollInbox(newRemoteDomain, enrolledInbox.address),
+      connectionManager.enrollInbox(remoteDomain, enrolledInbox.address),
     ).to.be.revertedWith('already inbox');
   });
 });


### PR DESCRIPTION
In favor of https://github.com/abacus-network/abacus-monorepo/pull/964

- Version validator manager domain hash derivation
- Version MultisigValidatorManager in bytecode const
- Add backwards compatibility comments
- Prevent reuse of domain hashes in ACM
- Add enrollInbox helper to ACM
- Add pragma to new interface
- Avoid namespace collision on helper
