### PR TITLE
Deploy testnet2 rc to use Gelato

### DIFF
--- a/typescript/infra/config/environments/testnet2/agent.ts
+++ b/typescript/infra/config/environments/testnet2/agent.ts
@@ -105,7 +105,7 @@ export const releaseCandidate: AgentConfig<TestnetChains> = {
   context: Contexts.ReleaseCandidate,
   docker: {
     repo: 'gcr.io/abacus-labs-dev/abacus-agent',
-    tag: 'sha-3e60d9a',
+    tag: 'sha-2d9f729',
   },
   aws: {
     region: 'us-east-1',


### PR DESCRIPTION
* Deploy RC to include #967 
* I don't think we should move to other contexts yet - I want to wait for the new API because right now we're hardcoding the max gas value as 5M gas. Their new API will handle gas estimation for us