### PR TITLE
Copy ICA pjson when building docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ COPY .yarn/releases ./.yarn/releases
 COPY typescript/utils/package.json ./typescript/utils/
 COPY typescript/sdk/package.json ./typescript/sdk/
 COPY typescript/helloworld/package.json ./typescript/helloworld/
+COPY typescript/ica/package.json ./typescript/ica/
 COPY typescript/infra/package.json ./typescript/infra/
 COPY solidity/core/package.json ./solidity/core/
 COPY solidity/app/package.json ./solidity/app/


### PR DESCRIPTION
Fixes [docker build failures](https://github.com/abacus-network/abacus-monorepo/actions/runs/3048745571/jobs/4914133249) introduced by https://github.com/abacus-network/abacus-monorepo/pull/1057